### PR TITLE
feat: Implement HistoryService export logic

### DIFF
--- a/src/worker/services/__tests__/history-service.test.ts
+++ b/src/worker/services/__tests__/history-service.test.ts
@@ -181,6 +181,42 @@ describe('HistoryService', () => {
     });
   });
 
+  describe('exportHistory', () => {
+    it('should validate conversationId', async () => {
+      const request: HistoryServiceRequest = {};
+      await expect(HistoryService.exportHistory(request)).rejects.toThrow('Conversation ID is required for export');
+    });
+
+    it('should return exported history in json format by default', async () => {
+      const request: HistoryServiceRequest = {
+        conversationId: 'conv-123'
+      };
+      const response = await HistoryService.exportHistory(request);
+      expect(response.success).toBe(true);
+      expect(response.metadata.format).toBe('json');
+      expect(response.metadata.conversationId).toBe('conv-123');
+      expect(response.data).toBeInstanceOf(Array);
+      expect(response.data?.length).toBe(1);
+      expect(typeof response.data?.[0]).toBe('string');
+      expect(response.data?.[0]).toBe('[]');
+    });
+
+    it('should return exported history in csv format when specified', async () => {
+      const request: HistoryServiceRequest = {
+        conversationId: 'conv-456',
+        metadata: { format: 'csv' }
+      };
+      const response = await HistoryService.exportHistory(request);
+      expect(response.success).toBe(true);
+      expect(response.metadata.format).toBe('csv');
+      expect(response.metadata.conversationId).toBe('conv-456');
+      expect(response.data).toBeInstanceOf(Array);
+      expect(response.data?.length).toBe(1);
+      expect(typeof response.data?.[0]).toBe('string');
+      expect(response.data?.[0]).toContain('id,timestamp,query,sources,total_results,accepted,rejected');
+    });
+  });
+
   describe('service response format', () => {
     it('should return properly structured response when implemented', () => {
       // Test getHistory response

--- a/src/worker/services/history-service.ts
+++ b/src/worker/services/history-service.ts
@@ -1,6 +1,8 @@
 // src/worker/services/history-service.ts
 // Service for history management operations (modular refactor)
 
+import { SearchHistoryManager } from '../lib/search-history-manager';
+
 export interface HistoryServiceRequest {
   conversationId?: string; // Optional for cross-conversation search
   entryId?: string;
@@ -65,8 +67,23 @@ export class HistoryService {
    * Exports conversation history
    */
   static async exportHistory(req: HistoryServiceRequest): Promise<HistoryServiceResponse> {
-    // TODO: Implement history export logic
-    throw new Error('Not implemented: HistoryService.exportHistory');
+    if (!req.conversationId) {
+      throw new Error('Conversation ID is required for export');
+    }
+
+    const format = req.metadata?.format === 'csv' ? 'csv' : 'json';
+    const manager = new SearchHistoryManager();
+    const exportData = await manager.exportHistory(req.conversationId, format);
+
+    return {
+      success: true,
+      data: [exportData],
+      metadata: {
+        conversationId: req.conversationId,
+        format,
+        exportedAt: new Date().toISOString()
+      }
+    };
   }
 
   /**


### PR DESCRIPTION
Implements the previously empty `exportHistory` method in `src/worker/services/history-service.ts`. The updated method now retrieves the exported search history via `SearchHistoryManager`, using the format defined in the request metadata (defaulting to 'json'). It handles invalid requests by throwing if no `conversationId` is provided. Added full test coverage for the success and error cases.

---
*PR created automatically by Jules for task [8413054242704426437](https://jules.google.com/task/8413054242704426437) started by @njtan142*