### PR TITLE
⚡ perf: parallelize runAutomaticCleanup database operations

### DIFF
--- a/run_benchmark.js
+++ b/run_benchmark.js
@@ -1,0 +1,57 @@
+// JavaScript Benchmark simulating the behavior
+
+async function clearOldData() {
+  // Simulate network/DB delay
+  await new Promise(r => setTimeout(r, 10));
+  return { deletedCount: 5 };
+}
+
+async function runBenchmark() {
+  const numUsers = 100;
+
+  const mockSettings = Array.from({ length: numUsers }).map((_, i) => ({
+    user_id: `user_${i}`,
+    conversation_id: undefined,
+    data_retention_days: 30
+  }));
+
+  const start = performance.now();
+  let totalDeleted = 0;
+  let usersProcessed = 0;
+
+  for (const setting of mockSettings) {
+    try {
+      const { deletedCount } = await clearOldData();
+      totalDeleted += deletedCount;
+      usersProcessed++;
+    } catch (error) {
+    }
+  }
+  const end = performance.now();
+
+  console.log(`Sequential baseline (simulated ${numUsers} users): ${(end - start).toFixed(2)}ms`);
+
+
+  const startParallel = performance.now();
+  totalDeleted = 0;
+  usersProcessed = 0;
+
+  const cleanupPromises = mockSettings.map(async (setting) => {
+    try {
+      const { deletedCount } = await clearOldData();
+      return deletedCount;
+    } catch (error) {
+      return 0;
+    }
+  });
+
+  const results = await Promise.all(cleanupPromises);
+  totalDeleted = results.reduce((acc, count) => acc + count, 0);
+  usersProcessed = results.length;
+
+  const endParallel = performance.now();
+  console.log(`Parallel execution (simulated ${numUsers} users): ${(endParallel - startParallel).toFixed(2)}ms`);
+
+}
+
+runBenchmark().catch(console.error);

--- a/run_benchmark.ts
+++ b/run_benchmark.ts
@@ -1,0 +1,116 @@
+import { PrivacyManager } from './src/worker/lib/privacy-manager.ts';
+
+// Create a simple benchmark for the runAutomaticCleanup method
+async function runBenchmark() {
+  const numUsers = 100;
+
+  // Create a mock env
+  const mockEnv = {
+    DB: {
+      prepare: () => ({
+        bind: () => ({
+          run: async () => ({ changes: 5 })
+        })
+      })
+    }
+  };
+
+  const privacyManager = new PrivacyManager(mockEnv);
+
+  // Mock the getSupabase behavior
+  const mockSupabase = {
+    from: (table: string) => {
+      if (table === 'privacy_settings') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: async () => {
+                // Return 100 mock user settings
+                const mockSettings = Array.from({ length: numUsers }).map((_, i) => ({
+                  user_id: `user_${i}`,
+                  conversation_id: null,
+                  data_retention_days: 30
+                }));
+                return { data: mockSettings, error: null };
+              }
+            })
+          })
+        };
+      } else {
+        return {
+          delete: () => ({
+            match: () => ({
+              lt: async () => ({ error: null })
+            })
+          })
+        };
+      }
+    }
+  };
+
+  // Patch getSupabase via prototype if needed, or we just mock require
+  const supabaseModule = await import('./src/worker/lib/supabase.ts');
+  const origGetSupabase = supabaseModule.getSupabase;
+  // This might not work cleanly with ESM, but let's try an alternative benchmark
+
+  // We can just redefine the runAutomaticCleanup method for benchmark
+  const oldClearOldData = privacyManager.clearOldData;
+  privacyManager.clearOldData = async () => {
+    // Simulate some work
+    await new Promise(r => setTimeout(r, 10));
+    return { deletedCount: 5 };
+  };
+
+  const start = performance.now();
+  let totalDeleted = 0;
+  let usersProcessed = 0;
+  const mockSettings = Array.from({ length: numUsers }).map((_, i) => ({
+    user_id: `user_${i}`,
+    conversation_id: undefined,
+    data_retention_days: 30
+  }));
+
+  for (const setting of mockSettings) {
+    try {
+      const { deletedCount } = await privacyManager.clearOldData(
+        setting.user_id as string,
+        setting.data_retention_days as number,
+        setting.conversation_id as string | undefined
+      );
+      totalDeleted += deletedCount;
+      usersProcessed++;
+    } catch (error) {
+    }
+  }
+  const end = performance.now();
+
+  console.log(`Sequential baseline (simulated ${numUsers} users): ${(end - start).toFixed(2)}ms`);
+
+
+  const startParallel = performance.now();
+  totalDeleted = 0;
+  usersProcessed = 0;
+
+  const cleanupPromises = mockSettings.map(async (setting) => {
+    try {
+      const { deletedCount } = await privacyManager.clearOldData(
+        setting.user_id as string,
+        setting.data_retention_days as number,
+        setting.conversation_id as string | undefined
+      );
+      return deletedCount;
+    } catch (error) {
+      return 0;
+    }
+  });
+
+  const results = await Promise.all(cleanupPromises);
+  totalDeleted = results.reduce((acc, count) => acc + count, 0);
+  usersProcessed = results.length;
+
+  const endParallel = performance.now();
+  console.log(`Parallel execution (simulated ${numUsers} users): ${(endParallel - startParallel).toFixed(2)}ms`);
+
+}
+
+runBenchmark().catch(console.error);

--- a/src/worker/lib/privacy-manager.ts
+++ b/src/worker/lib/privacy-manager.ts
@@ -740,17 +740,26 @@ export class PrivacyManager {
       let totalDeleted = 0;
       let usersProcessed = 0;
 
-      for (const setting of settings || []) {
+      const cleanupPromises = (settings || []).map(async (setting) => {
         try {
           const { deletedCount } = await this.clearOldData(
             setting.user_id as string,
             setting.data_retention_days as number,
             setting.conversation_id as string | undefined
           );
-          totalDeleted += deletedCount;
-          usersProcessed++;
+          return { deletedCount, success: true, userId: setting.user_id };
         } catch (error) {
           console.error(`Error cleaning up data for user ${setting.user_id}:`, error);
+          return { deletedCount: 0, success: false, userId: setting.user_id };
+        }
+      });
+
+      const results = await Promise.all(cleanupPromises);
+
+      for (const result of results) {
+        if (result.success) {
+          totalDeleted += result.deletedCount;
+          usersProcessed++;
         }
       }
 


### PR DESCRIPTION
💡 **What:** Refactored `runAutomaticCleanup` in `privacy-manager.ts` to execute user data cleanup queries in parallel using `Promise.all` rather than sequentially `await`-ing inside a `for...of` loop. Error handling is preserved within the map callback to prevent an entire batch from aborting if a single user's cleanup fails.
🎯 **Why:** The sequential `for...of` loop caused an N+1 query performance bottleneck where each database request waited for the previous one to complete, severely impacting performance for large numbers of users.
📊 **Measured Improvement:** A focused benchmark was created (`run_benchmark.js`) simulating a batch of 100 users with a simulated 10ms database latency per cleanup query. 
*   **Baseline (Sequential):** ~1038ms
*   **Improved (Parallel):** ~10ms
This demonstrates a ~99% reduction in execution time for the cleanup batch by fully utilizing parallel database I/O.

---
*PR created automatically by Jules for task [12388376554045405185](https://jules.google.com/task/12388376554045405185) started by @njtan142*