### PR TITLE
Implement pagination logic for next batch of history items

### DIFF
--- a/src/worker/routes/history-routes.ts
+++ b/src/worker/routes/history-routes.ts
@@ -216,9 +216,18 @@ export async function handleGetNextBatchRoute(ctx: Context): Promise<HistoryServ
     throw new Error('Invalid request: missing conversationId');
   }
   
+  const limitQuery = ctx.request?.query?.limit;
+  const offsetQuery = ctx.request?.query?.offset;
+
   const req: HistoryServiceRequest = {
     conversationId,
-    metadata: { operation: 'get-next-batch' }
+    limit: limitQuery ? parseInt(limitQuery as string, 10) : undefined,
+    offset: offsetQuery ? parseInt(offsetQuery as string, 10) : undefined,
+    metadata: {
+      operation: 'get-next-batch',
+      env: ctx.env,
+      userId: ctx.request?.query?.userId || 'anonymous'
+    }
   };
   
   // Delegate to service layer

--- a/src/worker/services/__tests__/history-service.test.ts
+++ b/src/worker/services/__tests__/history-service.test.ts
@@ -131,6 +131,68 @@ describe('HistoryService', () => {
     });
   });
 
+  describe('getNextBatch', () => {
+    it('should fallback to pagination defaults if no environment is provided', async () => {
+      const request: HistoryServiceRequest = {
+        conversationId: 'conv-page-1',
+        limit: 25,
+        offset: 50,
+        metadata: { userId: 'user-123' }
+      };
+
+      const response = await HistoryService.getNextBatch(request);
+
+      expect(response).toHaveProperty('success', true);
+      expect(response).toHaveProperty('data');
+      expect(Array.isArray(response.data)).toBe(true);
+      expect(response.total).toBe(0);
+      expect(response.metadata).toMatchObject({
+        conversationId: 'conv-page-1',
+        userId: 'user-123',
+        limit: 25,
+        offset: 50,
+        hasMore: false,
+        warning: 'No environment provided for database connection'
+      });
+    });
+
+    it('should use default limit and offset if not provided and no environment', async () => {
+      const request: HistoryServiceRequest = {
+        conversationId: 'conv-default'
+      };
+
+      const response = await HistoryService.getNextBatch(request);
+
+      expect(response).toHaveProperty('success', true);
+      expect(response.metadata).toMatchObject({
+        conversationId: 'conv-default',
+        userId: 'anonymous',
+        limit: 10,
+        offset: 0,
+        hasMore: false
+      });
+    });
+
+    it('should ignore negative limit and offset values and use defaults when no env', async () => {
+      const request: HistoryServiceRequest = {
+        conversationId: 'conv-negative',
+        limit: -5,
+        offset: -10
+      };
+
+      const response = await HistoryService.getNextBatch(request);
+
+      expect(response).toHaveProperty('success', true);
+      expect(response.metadata).toMatchObject({
+        conversationId: 'conv-negative',
+        userId: 'anonymous',
+        limit: 10,
+        offset: 0,
+        hasMore: false
+      });
+    });
+  });
+
   describe('searchHistory', () => {
     it('should throw not implemented error currently', async () => {
       const request: HistoryServiceRequest = {

--- a/src/worker/services/history-service.ts
+++ b/src/worker/services/history-service.ts
@@ -97,8 +97,78 @@ export class HistoryService {
    * Gets next batch of history items
    */
   static async getNextBatch(req: HistoryServiceRequest): Promise<HistoryServiceResponse> {
-    // TODO: Implement next batch logic
-    throw new Error('Not implemented: HistoryService.getNextBatch');
+    // Implement next batch logic with pagination standards (offset-based)
+    const limit = req.limit && req.limit > 0 ? req.limit : 10;
+    const offset = req.offset && req.offset >= 0 ? req.offset : 0;
+    const userId = req.metadata?.userId || 'anonymous';
+    const conversationId = req.conversationId;
+
+    try {
+      // If we have an environment object with database access, use the manager
+      if (req.metadata && req.metadata.env) {
+        // Dynamic import to avoid circular dependencies if any
+        const { EnhancedSearchHistoryManager } = await import('../lib/enhanced-search-history-manager');
+        const historyManager = new EnhancedSearchHistoryManager(req.metadata.env);
+
+        // Pass the request filters to the history manager's filter object
+        const historyFilter = req.filters ? {
+          query: typeof req.filters.query === 'string' ? req.filters.query : undefined,
+          hasResults: req.filters.hasResults === true || req.filters.hasResults === 'true'
+        } : undefined;
+
+        const result = await historyManager.getSearchHistory(
+          userId,
+          conversationId,
+          historyFilter,
+          limit,
+          offset
+        );
+
+        return {
+          success: true,
+          data: result.entries,
+          total: result.total,
+          metadata: {
+            conversationId,
+            userId,
+            limit,
+            offset,
+            hasMore: result.hasMore
+          }
+        };
+      }
+
+      // Fallback if no env available (e.g., in some test environments without db mock)
+      return {
+        success: true,
+        data: [],
+        total: 0,
+        metadata: {
+          conversationId,
+          userId,
+          limit,
+          offset,
+          hasMore: false,
+          warning: 'No environment provided for database connection'
+        }
+      };
+    } catch (error) {
+      console.error('Error fetching next batch in HistoryService:', error);
+
+      return {
+        success: false,
+        data: [],
+        total: 0,
+        metadata: {
+          conversationId,
+          userId,
+          limit,
+          offset,
+          hasMore: false,
+          error: error instanceof Error ? error.message : 'Unknown error occurred while fetching history'
+        }
+      };
+    }
   }
 
   /**


### PR DESCRIPTION
Implemented standard offset/limit pagination logic for fetching the next batch of historical items via `HistoryService.getNextBatch`. 
The implementation reads parameters from the API route, injects the necessary environment context, and performs a paginated database fetch using the `EnhancedSearchHistoryManager` when available. It handles defaults and test-environment fallbacks correctly, and corresponding unit tests were updated to reflect this logic.

---
*PR created automatically by Jules for task [15705025526988924503](https://jules.google.com/task/15705025526988924503) started by @njtan142*