### PR TITLE
🧪 Add tests for BibliographyControls

### DIFF
--- a/src/tests/bibliography-controls.test.tsx
+++ b/src/tests/bibliography-controls.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BibliographyControls } from '../components/ui/bibliography-controls';
+import { CitationStyle } from '../lib/ai-types';
+
+describe('BibliographyControls', () => {
+  it('renders the component with default APA style', () => {
+    render(<BibliographyControls />);
+
+    expect(screen.getByText('Bibliography Controls')).toBeInTheDocument();
+
+    // Check if the select has APA as default
+    const selectTrigger = screen.getByRole('combobox');
+    expect(selectTrigger).toHaveTextContent('APA');
+
+    // Check export buttons
+    expect(screen.getByRole('button', { name: /bibtex/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ris/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /json/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /csv/i })).toBeInTheDocument();
+  });
+
+  it('renders with a specific citation style', () => {
+    render(<BibliographyControls citationStyle={CitationStyle.MLA} />);
+
+    const selectTrigger = screen.getByRole('combobox');
+    expect(selectTrigger).toHaveTextContent('MLA');
+  });
+
+  it('calls onStyleChange when a new style is selected', async () => {
+    const onStyleChange = vi.fn();
+    render(<BibliographyControls onStyleChange={onStyleChange} />);
+
+    // Open the select dropdown
+    const selectTrigger = screen.getByRole('combobox');
+    await userEvent.click(selectTrigger);
+
+    // Select Chicago style
+    const option = screen.getByRole('option', { name: 'Chicago' });
+    await userEvent.click(option);
+
+    expect(onStyleChange).toHaveBeenCalledTimes(1);
+    expect(onStyleChange).toHaveBeenCalledWith(CitationStyle.CHICAGO);
+  });
+
+  it('calls onExport with correct format when buttons are clicked', async () => {
+    const onExport = vi.fn();
+    render(<BibliographyControls onExport={onExport} />);
+
+    // Click BibTeX
+    await userEvent.click(screen.getByRole('button', { name: /bibtex/i }));
+    expect(onExport).toHaveBeenCalledTimes(1);
+    expect(onExport).toHaveBeenLastCalledWith('bibtex');
+
+    // Click RIS
+    await userEvent.click(screen.getByRole('button', { name: /ris/i }));
+    expect(onExport).toHaveBeenCalledTimes(2);
+    expect(onExport).toHaveBeenLastCalledWith('ris');
+
+    // Click JSON
+    await userEvent.click(screen.getByRole('button', { name: /json/i }));
+    expect(onExport).toHaveBeenCalledTimes(3);
+    expect(onExport).toHaveBeenLastCalledWith('json');
+
+    // Click CSV
+    await userEvent.click(screen.getByRole('button', { name: /csv/i }));
+    expect(onExport).toHaveBeenCalledTimes(4);
+    expect(onExport).toHaveBeenLastCalledWith('csv');
+  });
+
+  it('handles missing onStyleChange callback without throwing', async () => {
+    // Render without onStyleChange
+    render(<BibliographyControls />);
+
+    // Open the select dropdown
+    const selectTrigger = screen.getByRole('combobox');
+    await userEvent.click(selectTrigger);
+
+    // Select an option, shouldn't throw error
+    const option = screen.getByRole('option', { name: 'MLA' });
+    await userEvent.click(option);
+
+    // If it reached here without throwing, test passes
+    expect(true).toBe(true);
+  });
+
+  it('handles missing onExport callback without throwing', async () => {
+    // Render without onExport
+    render(<BibliographyControls />);
+
+    // Click a button, shouldn't throw error
+    await userEvent.click(screen.getByRole('button', { name: /bibtex/i }));
+
+    // If it reached here without throwing, test passes
+    expect(true).toBe(true);
+  });
+});

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -29,3 +29,30 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: () => {},
   }),
 })
+if (typeof window !== 'undefined') {
+  if (!window.HTMLElement.prototype.scrollIntoView) {
+    window.HTMLElement.prototype.scrollIntoView = function() {};
+  }
+  if (!window.PointerEvent) {
+    class PointerEvent extends Event {
+      pointerId: number;
+      constructor(type: string, params: any = {}) {
+        super(type, params);
+        this.pointerId = params.pointerId || 0;
+      }
+    }
+    (window as any).PointerEvent = PointerEvent;
+  }
+}
+
+if (typeof Element !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing tests for `src/components/ui/bibliography-controls.tsx`.
- Radix UI dependencies lacked correct global jsdom test support, causing tests referencing Shadcn `<Select>` elements to fail.

📊 **Coverage:** What scenarios are now tested
- Validates the default initial state (`APA` style rendering).
- Validates pre-selecting a specific style.
- Validates interaction logic: selecting a new format from the combobox triggers `onStyleChange` callback.
- Validates interaction logic: clicking export buttons triggers `onExport` callback with correct export formats (`bibtex`, `ris`, `json`, `csv`).
- Validates safe fallbacks (missing callbacks do not throw errors).

✨ **Result:** The improvement in test coverage
- Added 6 robust user-interaction-based unit tests for the `BibliographyControls` component that will securely catch bugs in refactoring attempts.
- Injected vital `PointerEvent` and `scrollIntoView` stubs into `src/tests/setup.ts` to allow confident, fast jsdom-based unit tests for *any* Shadcn/Radix select component moving forward.

---
*PR created automatically by Jules for task [11938205693854722277](https://jules.google.com/task/11938205693854722277) started by @njtan142*