### PR TITLE
Implement getSearchSessionDetails in HistoryService

### DIFF
--- a/src/tests/history-service.test.ts
+++ b/src/tests/history-service.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HistoryService } from '../worker/services/history-service';
+
+vi.mock('../worker/lib/enhanced-search-history-manager', () => {
+  return {
+    EnhancedSearchHistoryManager: vi.fn().mockImplementation(() => {
+      return {
+        getSearchSessionDetails: vi.fn().mockImplementation((sessionId: string) => {
+          if (sessionId === 'valid-session-id') {
+            return Promise.resolve({
+              session: { id: 'valid-session-id' },
+              results: []
+            });
+          }
+          return Promise.resolve(null);
+        })
+      };
+    })
+  };
+});
+
+describe('HistoryService.getSearchSessionDetails', () => {
+  it('should throw if missing sessionId', async () => {
+    await expect(HistoryService.getSearchSessionDetails({ env: {} } as any)).rejects.toThrow('missing sessionId');
+  });
+
+  it('should throw if missing env', async () => {
+    await expect(HistoryService.getSearchSessionDetails({ metadata: { sessionId: '123' } } as any)).rejects.toThrow('Environment object is required');
+  });
+
+  it('should return session details if valid', async () => {
+    const res = await HistoryService.getSearchSessionDetails({
+      metadata: { sessionId: 'valid-session-id' },
+      env: {}
+    } as any);
+
+    expect(res.success).toBe(true);
+    expect(res.data).toBeDefined();
+    expect(res.data![0].session.id).toBe('valid-session-id');
+  });
+
+  it('should return success false if not found', async () => {
+    const res = await HistoryService.getSearchSessionDetails({
+      metadata: { sessionId: 'invalid-session-id' },
+      env: {}
+    } as any);
+
+    expect(res.success).toBe(false);
+    expect(res.metadata.error).toBe('Session not found');
+  });
+});

--- a/src/worker/services/history-service.ts
+++ b/src/worker/services/history-service.ts
@@ -435,7 +435,53 @@ export class HistoryService {
    * Gets search session details
    */
   static async getSearchSessionDetails(req: HistoryServiceRequest): Promise<HistoryServiceResponse> {
-    // TODO: Implement session details logic
-    throw new Error('Not implemented: HistoryService.getSearchSessionDetails');
+    const sessionId = req.metadata?.sessionId;
+
+    if (!sessionId) {
+      throw new Error('Invalid request: missing sessionId in metadata');
+    }
+
+    if (!req.env) {
+      throw new Error('Environment object is required for getting session details');
+    }
+
+    try {
+      // Dynamic import to avoid circular dependencies if any
+      const { EnhancedSearchHistoryManager } = await import('../lib/enhanced-search-history-manager');
+      const manager = new EnhancedSearchHistoryManager(req.env);
+
+      const details = await manager.getSearchSessionDetails(sessionId);
+
+      if (!details) {
+        return {
+          success: false,
+          metadata: {
+            operation: 'get-session-details',
+            sessionId,
+            error: 'Session not found'
+          }
+        };
+      }
+
+      return {
+        success: true,
+        data: [details],
+        metadata: {
+          operation: 'get-session-details',
+          sessionId
+        }
+      };
+    } catch (error) {
+      console.error('Error fetching search session details:', error);
+
+      return {
+        success: false,
+        metadata: {
+          operation: 'get-session-details',
+          sessionId,
+          error: error instanceof Error ? error.message : 'Unknown error occurred while fetching session details'
+        }
+      };
+    }
   }
 }


### PR DESCRIPTION
Implements the `getSearchSessionDetails` function in the `HistoryService`. It uses `EnhancedSearchHistoryManager` to get deep information about a specific session (including results, feedback, metrics, etc).

Includes basic error boundary checks to ensure `req.metadata.sessionId` and `req.env` are available before processing. Uses dynamic import for `EnhancedSearchHistoryManager` to match the file's style and avoid circular deps.

Added tests for this method inside a new `src/tests/history-service.test.ts` file.

---
*PR created automatically by Jules for task [600320950386414785](https://jules.google.com/task/600320950386414785) started by @njtan142*