### PR TITLE
Implement history retrieval logic in HistoryService

### DIFF
--- a/src/worker/services/__tests__/history-service.test.ts
+++ b/src/worker/services/__tests__/history-service.test.ts
@@ -10,37 +10,70 @@ describe('HistoryService', () => {
   });
 
   describe('getHistory', () => {
-    it('should throw not implemented error currently', async () => {
+    it('should fallback to pagination defaults if no environment is provided', async () => {
       const request: HistoryServiceRequest = {
         conversationId: 'conv-123',
-        limit: 10,
-        offset: 0
-      };
-      
-      await expect(HistoryService.getHistory(request)).rejects.toThrow('Not implemented: HistoryService.getHistory');
-    });
-
-    it('should handle pagination parameters when implemented', async () => {
-      const paginatedRequest: HistoryServiceRequest = {
-        conversationId: 'conv-456',
         limit: 25,
         offset: 50,
-        filters: { 
-          dateRange: { start: '2023-01-01', end: '2023-01-31' },
-          entryType: 'search'
-        }
+        metadata: { userId: 'user-123' }
       };
 
-      await expect(HistoryService.getHistory(paginatedRequest)).rejects.toThrow('Not implemented');
+      const response = await HistoryService.getHistory(request);
+
+      expect(response).toHaveProperty('success', true);
+      expect(response).toHaveProperty('data');
+      expect(Array.isArray(response.data)).toBe(true);
+      expect(response.total).toBe(0);
+      expect(response.metadata).toMatchObject({
+        conversationId: 'conv-123',
+        limit: 25,
+        offset: 50,
+        hasMore: false,
+        warning: 'No environment provided for database connection'
+      });
     });
 
-    it('should validate conversationId when implemented', async () => {
+    it('should use default limit and offset if not provided and no environment', async () => {
+      const request: HistoryServiceRequest = {
+        conversationId: 'conv-default'
+      };
+
+      const response = await HistoryService.getHistory(request);
+
+      expect(response).toHaveProperty('success', true);
+      expect(response.metadata).toMatchObject({
+        conversationId: 'conv-default',
+        limit: 10,
+        offset: 0,
+        hasMore: false
+      });
+    });
+
+    it('should ignore negative limit and offset values and use defaults when no env', async () => {
+      const request: HistoryServiceRequest = {
+        conversationId: 'conv-negative',
+        limit: -5,
+        offset: -10
+      };
+
+      const response = await HistoryService.getHistory(request);
+
+      expect(response).toHaveProperty('success', true);
+      expect(response.metadata).toMatchObject({
+        conversationId: 'conv-negative',
+        limit: 10,
+        offset: 0,
+        hasMore: false
+      });
+    });
+
+    it('should validate conversationId', async () => {
       const invalidRequest: HistoryServiceRequest = {
         conversationId: '',
         limit: 10
       };
 
-      await expect(HistoryService.getHistory(invalidRequest)).rejects.toThrow('Not implemented');
+      await expect(HistoryService.getHistory(invalidRequest)).rejects.toThrow('Invalid request: missing conversationId');
     });
   });
 

--- a/src/worker/services/history-service.ts
+++ b/src/worker/services/history-service.ts
@@ -33,8 +33,80 @@ export class HistoryService {
    * Retrieves conversation history
    */
   static async getHistory(req: HistoryServiceRequest): Promise<HistoryServiceResponse> {
-    // TODO: Implement history retrieval logic
-    throw new Error('Not implemented: HistoryService.getHistory');
+    if (!req.conversationId) {
+      throw new Error('Invalid request: missing conversationId');
+    }
+
+    const limit = req.limit && req.limit > 0 ? req.limit : 10;
+    const offset = req.offset && req.offset >= 0 ? req.offset : 0;
+
+    let userId = 'anonymous';
+    if (req.token && req.env?.SUPABASE_JWT_SECRET) {
+      userId = await getUserIdFromToken(req.token, req.env.SUPABASE_JWT_SECRET) || 'anonymous';
+    } else if (req.metadata?.userId) {
+      userId = req.metadata.userId;
+    }
+
+    try {
+      if (req.env) {
+        const { EnhancedSearchHistoryManager } = await import('../lib/enhanced-search-history-manager');
+        const historyManager = new EnhancedSearchHistoryManager(req.env);
+
+        const historyFilter = req.filters ? {
+          query: typeof req.filters.query === 'string' ? req.filters.query : undefined,
+          hasResults: req.filters.hasResults === true || req.filters.hasResults === 'true'
+        } : undefined;
+
+        const result = await historyManager.getSearchHistory(
+          userId,
+          req.conversationId,
+          historyFilter,
+          limit,
+          offset
+        );
+
+        return {
+          success: true,
+          data: result.entries,
+          total: result.total,
+          metadata: {
+            conversationId: req.conversationId,
+            limit,
+            offset,
+            hasMore: result.hasMore
+          }
+        };
+      }
+
+      // Fallback if no env available
+      return {
+        success: true,
+        data: [],
+        total: 0,
+        metadata: {
+          conversationId: req.conversationId,
+          limit,
+          offset,
+          hasMore: false,
+          warning: 'No environment provided for database connection'
+        }
+      };
+    } catch (error) {
+      console.error('Error fetching history in HistoryService:', error);
+
+      return {
+        success: false,
+        data: [],
+        total: 0,
+        metadata: {
+          conversationId: req.conversationId,
+          limit,
+          offset,
+          hasMore: false,
+          error: error instanceof Error ? error.message : 'Unknown error occurred while fetching history'
+        }
+      };
+    }
   }
 
   /**
@@ -198,7 +270,7 @@ export class HistoryService {
 
     let userId: string | null = null;
     if (req.token) {
-      userId = await getUserIdFromToken(req.token);
+      userId = await getUserIdFromToken(req.token, req.env?.SUPABASE_JWT_SECRET || '');
     } else if (req.metadata?.userId) {
       userId = req.metadata.userId;
     }


### PR DESCRIPTION
Implemented the `getHistory` function in `HistoryService` to retrieve a user's conversation search history. It includes pagination via `limit` and `offset`, user ID parsing from JWT, uses the `EnhancedSearchHistoryManager` to query the Supabase database, and returns standard success tracking payloads matching the required response schema. Additionally updated the corresponding unit tests to reflect the implemented behavior. Fixed an existing, unrelated issue inside the same file that could cause a runtime crash.

---
*PR created automatically by Jules for task [12651435326772725758](https://jules.google.com/task/12651435326772725758) started by @njtan142*