### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in AppSidebar

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -204,6 +204,7 @@ export function AppSidebar({
                           size="icon"
                           className="h-9 w-9 shrink-0"
                           onClick={() => handleSaveEdit(item.id)}
+                          aria-label="Save title"
                           disabled={isUpdating}
                         >
                           {isUpdating ? (
@@ -217,6 +218,7 @@ export function AppSidebar({
                           size="icon"
                           className="h-9 w-9 shrink-0"
                           onClick={handleCancelEdit}
+                          aria-label="Cancel editing"
                           disabled={isUpdating}
                         >
                           <X className="h-5 w-5 text-destructive" />
@@ -235,6 +237,7 @@ export function AppSidebar({
                               className="h-8 w-8"
                               onClick={(e) => handleStartEdit(item, e)}
                               title="Edit title"
+                              aria-label="Edit title"
                             >
                               <Pencil className="h-4 w-4" />
                             </Button>
@@ -246,6 +249,7 @@ export function AppSidebar({
                               className="h-8 w-8"
                               onClick={(e) => handleRegenerateTitle(item.id, e)}
                               disabled={regeneratingId === item.id}
+                              aria-label="Regenerate title with AI"
                               title="Regenerate title with AI"
                             >
                               {regeneratingId === item.id ? (
@@ -261,6 +265,7 @@ export function AppSidebar({
                             className="h-8 w-8"
                             onClick={() => onDelete(item.id)}
                             title="Delete"
+                            aria-label="Delete idea"
                           >
                             <Trash className="h-4 w-4" />
                           </Button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the 5 icon-only buttons used for item actions (Save, Cancel, Edit, Regenerate, Delete) within the sidebar items.
🎯 **Why**: These buttons previously relied solely on icons (`<Loader2>`, `<Check>`, `<X>`, `<Pencil>`, `<Sparkles>`, `<Trash>`) or tooltip `title`s to convey their purpose. `title` attributes are not reliably announced by all screen readers. Adding explicit `aria-label`s ensures screen reader users can accurately identify the actions associated with each button, thereby improving keyboard navigation and overall accessibility.
📸 **Before/After**: N/A (Non-visual change)
♿ **Accessibility**: Enhanced screen reader support for the primary interactive elements within the `AppSidebar`'s idea list.

---
*PR created automatically by Jules for task [14754122957633773460](https://jules.google.com/task/14754122957633773460) started by @njtan142*