### PR TITLE
🎨 Palette: Add ARIA labels to icon-only chat buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-09 - ARIA labels for dynamic elements
 **Learning:** For interactive UI elements created in loops (like star ratings), dynamic `aria-label`s (e.g. `aria-label={`Rate ${star} out of 5 stars`}`) provide critical context for screen readers that static text cannot.
 **Action:** Always verify that interactive map-generated components have clear, context-aware `aria-label` attributes.
+## 2024-03-10 - Icon-Only Button Accessibility Pattern
+**Learning:** Icon-only buttons (like thumbs up/down, scroll to bottom) in the chat interface were consistently missing `aria-label`s, which is a common accessibility trap in chat UIs where screen real estate is tight. While `CopyButton` correctly handles this internally, raw Shadcn `<Button>` components wrapping Lucide icons need explicit labels to be announced correctly by screen readers.
+**Action:** Always check any `<Button size="icon">` usages across the codebase for missing `aria-label`s, especially in dynamic lists or dense UIs like chat messages.

--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -244,6 +244,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-up")}
+            aria-label="Rate response as helpful"
           >
             <ThumbsUp className="h-4 w-4" />
           </Button>
@@ -252,6 +253,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-down")}
+            aria-label="Rate response as unhelpful"
           >
             <ThumbsDown className="h-4 w-4" />
           </Button>
@@ -366,6 +368,7 @@ export function ChatMessages({
               className="pointer-events-auto h-8 w-8 rounded-full ease-in-out animate-in fade-in-0 slide-in-from-bottom-1"
               size="icon"
               variant="ghost"
+              aria-label="Scroll to bottom"
             >
               <ArrowDown className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "Thumbs Up", "Thumbs Down", and "Scroll to Bottom" icon-only `<Button>` components in the main Chat interface.
🎯 Why: Icon-only buttons without accessible names cannot be understood by screen readers, creating a barrier for users relying on assistive technology. This ensures the purpose of these interactions is clearly announced.
♿ Accessibility: Improved screen reader support by providing explicit labels ("Rate response as helpful", "Rate response as unhelpful", and "Scroll to bottom").

---
*PR created automatically by Jules for task [3864538480018490599](https://jules.google.com/task/3864538480018490599) started by @njtan142*