### PR TITLE
⚡ Bolt: Optimize search results recording with batch insert

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2024-03-09 - AppSidebar Unnecessary Recalculations
-**Learning:** React sidebars that manage their own local state (like editing states) and also filter parent-provided arrays (like `items`) must memoize the filtering operation, otherwise every local state change triggers an O(N) recalculation.
-**Action:** Always wrap array filtering and derived object creation in `useMemo` when they depend on props in a component that frequently re-renders due to unrelated local state changes.
+## 2024-03-10 - [Batch Insert for Search Analytics]
+**Learning:** Found an N+1 query problem where `recordSearchResult` was being called individually for each search result returned. This can significantly slow down the overall request if the search returns many results (like 10-20 search results in academic queries).
+**Action:** Introduced a `recordSearchResults` function in the `SearchAnalyticsManager` to insert an array of objects into the database in a single `supabase.from().insert(recordsToInsert)` call. Always look for iteration (`for...of`) around database operations as a prime candidate for performance optimization using batching.

--- a/src/worker/lib/search-analytics-manager.ts
+++ b/src/worker/lib/search-analytics-manager.ts
@@ -171,6 +171,59 @@ export class SearchAnalyticsManager {
   /**
    * Record a search result interaction
    */
+
+  /**
+   * Batch record multiple search results in a single database operation
+   * Performance optimization: Turns N database inserts into 1
+   */
+  async recordSearchResults(resultsData: Omit<SearchResult, 'id' | 'createdAt'>[]): Promise<string[]> {
+    if (!resultsData || resultsData.length === 0) {
+      return [];
+    }
+
+    try {
+      const supabase = getSupabase(this.env);
+      const recordsToInsert = resultsData.map(data => {
+        const resultId = crypto.randomUUID();
+        return {
+          id: resultId,
+          search_session_id: data.searchSessionId,
+          reference_id: data.referenceId || null,
+          result_title: data.resultTitle,
+          result_authors: data.resultAuthors,
+          result_journal: data.resultJournal || null,
+          result_year: data.resultYear || null,
+          result_doi: data.resultDoi || null,
+          result_url: data.resultUrl || null,
+          relevance_score: data.relevanceScore,
+          confidence_score: data.confidenceScore,
+          quality_score: data.qualityScore,
+          citation_count: data.citationCount,
+          user_action: data.userAction || null,
+          user_feedback_rating: data.userFeedbackRating || null,
+          user_feedback_comments: data.userFeedbackComments || null,
+          added_to_library: data.addedToLibrary,
+          added_at: data.addedAt?.toISOString() || null
+        };
+      });
+
+      const { error } = await supabase
+        .from('search_results')
+        .insert(recordsToInsert);
+
+      if (error) {
+        console.error('Error batch recording search results:', error);
+        throw error;
+      }
+
+      console.log(`Batch recorded ${recordsToInsert.length} search results`);
+      return recordsToInsert.map(record => record.id);
+    } catch (error) {
+      console.error('Error batch recording search results:', error);
+      throw error;
+    }
+  }
+
   async recordSearchResult(resultData: Omit<SearchResult, 'id' | 'createdAt'>): Promise<string> {
     const resultId = crypto.randomUUID();
     

--- a/src/worker/services/search-service.ts
+++ b/src/worker/services/search-service.ts
@@ -476,22 +476,21 @@ export class SearchService {
       if (sessionId && env) {
         try {
           const analyticsManager = this.getAnalyticsManager(env);
-          for (const result of finalResults) {
-            await analyticsManager.recordSearchResult({
-              searchSessionId: sessionId,
-              resultTitle: result.title,
-              resultAuthors: result.authors,
-              resultJournal: result.journal,
-              resultYear: result.publication_date ? parseInt(result.publication_date) : undefined,
-              resultDoi: result.doi,
-              resultUrl: result.url,
-              relevanceScore: result.relevance_score || 0,
-              confidenceScore: result.confidence || 0,
-              qualityScore: this.calculateQualityScore(result),
-              citationCount: result.citation_count || 0,
-              addedToLibrary: false,
-            });
-          }
+          // Use batch insert to fix N+1 query problem
+          await analyticsManager.recordSearchResults(finalResults.map(result => ({
+            searchSessionId: sessionId,
+            resultTitle: result.title,
+            resultAuthors: result.authors,
+            resultJournal: result.journal,
+            resultYear: result.publication_date ? parseInt(result.publication_date) : undefined,
+            resultDoi: result.doi,
+            resultUrl: result.url,
+            relevanceScore: result.relevance_score || 0,
+            confidenceScore: result.confidence || 0,
+            qualityScore: this.calculateQualityScore(result),
+            citationCount: result.citation_count || 0,
+            addedToLibrary: false,
+          })));
 
           const processingTime = Date.now() - startTime;
           await this.updateSearchSession(env, sessionId, {

--- a/update_search_analytics_manager.cjs
+++ b/update_search_analytics_manager.cjs
@@ -1,0 +1,67 @@
+const fs = require('fs');
+
+const filePath = 'src/worker/lib/search-analytics-manager.ts';
+let code = fs.readFileSync(filePath, 'utf8');
+
+const newMethod = `
+  /**
+   * Batch record multiple search results in a single database operation
+   * Performance optimization: Turns N database inserts into 1
+   */
+  async recordSearchResults(resultsData: Omit<SearchResult, 'id' | 'createdAt'>[]): Promise<string[]> {
+    if (!resultsData || resultsData.length === 0) {
+      return [];
+    }
+
+    try {
+      const supabase = getSupabase(this.env);
+      const recordsToInsert = resultsData.map(data => {
+        const resultId = crypto.randomUUID();
+        return {
+          id: resultId,
+          search_session_id: data.searchSessionId,
+          reference_id: data.referenceId || null,
+          result_title: data.resultTitle,
+          result_authors: data.resultAuthors,
+          result_journal: data.resultJournal || null,
+          result_year: data.resultYear || null,
+          result_doi: data.resultDoi || null,
+          result_url: data.resultUrl || null,
+          relevance_score: data.relevanceScore,
+          confidence_score: data.confidenceScore,
+          quality_score: data.qualityScore,
+          citation_count: data.citationCount,
+          user_action: data.userAction || null,
+          user_feedback_rating: data.userFeedbackRating || null,
+          user_feedback_comments: data.userFeedbackComments || null,
+          added_to_library: data.addedToLibrary,
+          added_at: data.addedAt?.toISOString() || null
+        };
+      });
+
+      const { error } = await supabase
+        .from('search_results')
+        .insert(recordsToInsert);
+
+      if (error) {
+        console.error('Error batch recording search results:', error);
+        throw error;
+      }
+
+      console.log(\`Batch recorded \${recordsToInsert.length} search results\`);
+      return recordsToInsert.map(record => record.id);
+    } catch (error) {
+      console.error('Error batch recording search results:', error);
+      throw error;
+    }
+  }
+`;
+
+const insertIndex = code.indexOf("  async recordSearchResult(resultData: Omit<SearchResult, 'id' | 'createdAt'>): Promise<string> {");
+if (insertIndex !== -1) {
+  code = code.slice(0, insertIndex) + newMethod + '\n' + code.slice(insertIndex);
+  fs.writeFileSync(filePath, code);
+  console.log('Successfully added recordSearchResults method.');
+} else {
+  console.log('Could not find insertion point.');
+}

--- a/update_search_service.cjs
+++ b/update_search_service.cjs
@@ -1,0 +1,45 @@
+const fs = require('fs');
+
+const filePath = 'src/worker/services/search-service.ts';
+let code = fs.readFileSync(filePath, 'utf8');
+
+const search = `          for (const result of finalResults) {
+            await analyticsManager.recordSearchResult({
+              searchSessionId: sessionId,
+              resultTitle: result.title,
+              resultAuthors: result.authors,
+              resultJournal: result.journal,
+              resultYear: result.publication_date ? parseInt(result.publication_date) : undefined,
+              resultDoi: result.doi,
+              resultUrl: result.url,
+              relevanceScore: result.relevance_score || 0,
+              confidenceScore: result.confidence || 0,
+              qualityScore: this.calculateQualityScore(result),
+              citationCount: result.citation_count || 0,
+              addedToLibrary: false,
+            });
+          }`;
+
+const replace = `          // Use batch insert to fix N+1 query problem
+          await analyticsManager.recordSearchResults(finalResults.map(result => ({
+            searchSessionId: sessionId,
+            resultTitle: result.title,
+            resultAuthors: result.authors,
+            resultJournal: result.journal,
+            resultYear: result.publication_date ? parseInt(result.publication_date) : undefined,
+            resultDoi: result.doi,
+            resultUrl: result.url,
+            relevanceScore: result.relevance_score || 0,
+            confidenceScore: result.confidence || 0,
+            qualityScore: this.calculateQualityScore(result),
+            citationCount: result.citation_count || 0,
+            addedToLibrary: false,
+          })));`;
+
+if (code.includes(search)) {
+  code = code.replace(search, replace);
+  fs.writeFileSync(filePath, code);
+  console.log('Successfully updated search-service.ts to use batch insert.');
+} else {
+  console.log('Could not find search block in search-service.ts.');
+}


### PR DESCRIPTION
💡 **What:** Added `recordSearchResults` to `SearchAnalyticsManager` to support batch inserts, and updated `SearchService` to pass the `finalResults` array directly to this new method instead of iterating and inserting one by one.

🎯 **Why:** Previously, the code iterated over the `finalResults` array and performed a separate `INSERT` operation for every single result returned by the search API (an N+1 database problem). For large lists of academic papers, this adds considerable latency to the search endpoint response time.

📊 **Impact:** Reduces database `INSERT` network calls from N (number of search results) to 1. Expected to noticeably improve end-to-end response time for large academic search queries.

🔬 **Measurement:** Verify the optimization by checking the Search endpoints' overall response time, or inspecting network requests/database logs to see a single bulk insert array instead of numerous individual queries in `analytics_events`.

---
*PR created automatically by Jules for task [10446048621348058456](https://jules.google.com/task/10446048621348058456) started by @njtan142*