### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix IDOR in Get Messages Endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Fix IDOR in Get Messages Endpoint]
+**Vulnerability:** The `/api/chats/:id/messages` endpoint was susceptible to Insecure Direct Object Reference (IDOR). It fetched and returned chat messages simply by using the `chatId` from the route parameter without verifying if the authenticated user actually owned the chat.
+**Learning:** Endpoints that operate on sub-resources (like messages) often assume the parent resource (like chat) was already authorized in previous steps, leading to missing ownership checks at the data access layer.
+**Prevention:** Always verify the ownership of the parent resource against the authenticated user's ID before allowing access to its nested resources or data. In Supabase, query the parent table with the authenticated user ID and the resource ID to assert ownership.

--- a/src/worker/handlers/messages.ts
+++ b/src/worker/handlers/messages.ts
@@ -1,10 +1,35 @@
 import { Context } from 'hono';
 import { getSupabase, SupabaseEnv } from '../lib/supabase';
 import { Env } from '../types/env';
+import { getUserIdFromToken } from '../lib/auth-utils';
 
 export async function getMessagesHandler(c: Context<{ Bindings: Env & SupabaseEnv }>) {
     const chatId = c.req.param("id");
     const supabase = getSupabase(c.env);
+
+    // Get userId from Authorization header
+    const authHeader = c.req.header('Authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+        return c.json({ error: "Authentication required" }, 401);
+    }
+
+    const userId = await getUserIdFromToken(token, c.env.SUPABASE_JWT_SECRET);
+    if (!userId) {
+        return c.json({ error: "Invalid token" }, 401);
+    }
+
+    // SECURITY: Verify chat belongs to authenticated user to prevent IDOR
+    const { data: chatData } = await supabase
+        .from("chats")
+        .select("user_id")
+        .eq("id", chatId)
+        .single();
+
+    if (!chatData || chatData.user_id !== userId) {
+        return c.json({ error: "Chat not found or unauthorized" }, 403);
+    }
 
     const { data, error } = await supabase
         .from("messages")


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix IDOR in Get Messages Endpoint

🚨 Severity: HIGH
💡 Vulnerability: The getMessagesHandler fetched and returned messages simply by querying the database for a provided chatId, without checking if the chat actually belonged to the authenticated user.
🎯 Impact: An attacker could enumerate chatIds and access other users' private messages.
🔧 Fix: Extracted user ID from the JWT token and verified the authenticated user owns the requested chat before fetching messages.
✅ Verification: Ensure the endpoint rejects queries for valid chatIds that belong to other users with a 403 Forbidden.

---
*PR created automatically by Jules for task [17743910918055728388](https://jules.google.com/task/17743910918055728388) started by @njtan142*