### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -244,6 +244,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-up")}
+            aria-label="Thumbs up"
           >
             <ThumbsUp className="h-4 w-4" />
           </Button>
@@ -252,6 +253,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-down")}
+            aria-label="Thumbs down"
           >
             <ThumbsDown className="h-4 w-4" />
           </Button>

--- a/src/components/ui/tools-panel.tsx
+++ b/src/components/ui/tools-panel.tsx
@@ -59,6 +59,7 @@ export const ToolsPanel: React.FC<ToolsPanelProps> = ({
             ? "-left-4" // Center when open
             : "-left-10" // More to the right when closed
         )}
+        aria-label={isOpen ? "Close tools panel" : "Open tools panel"}
       >
         {isOpen ? (
           <ChevronRight className="h-4 w-4" />

--- a/src/tests/components/ui/chat-aria.test.tsx
+++ b/src/tests/components/ui/chat-aria.test.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Chat } from '../../../components/ui/chat'
+import React from 'react'
+
+test('Chat component renders rating buttons with aria-labels', () => {
+  render(
+    <Chat
+      messages={[{ id: '1', role: 'assistant', content: 'Hello' }]}
+      input=""
+      handleInputChange={() => {}}
+      handleSubmit={() => {}}
+      isGenerating={false}
+      onRateResponse={() => {}}
+    />
+  )
+
+  const thumbsUpBtn = screen.getByLabelText('Thumbs up')
+  const thumbsDownBtn = screen.getByLabelText('Thumbs down')
+
+  expect(thumbsUpBtn).toBeInTheDocument()
+  expect(thumbsDownBtn).toBeInTheDocument()
+})

--- a/src/tests/components/ui/tools-panel-aria.test.tsx
+++ b/src/tests/components/ui/tools-panel-aria.test.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ToolsPanel } from '../../../components/ui/tools-panel'
+import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+
+test('ToolsPanel component renders toggle button with aria-label', () => {
+  render(
+    <BrowserRouter>
+      <ToolsPanel currentConversation={{ id: '1', title: 'Test' }} />
+    </BrowserRouter>
+  )
+
+  const openBtn = screen.getByLabelText('Open tools panel')
+  expect(openBtn).toBeInTheDocument()
+
+  fireEvent.click(openBtn)
+
+  const closeBtn = screen.getByLabelText('Close tools panel')
+  expect(closeBtn).toBeInTheDocument()
+})


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons in `chat.tsx` (Thumbs up/down) and `tools-panel.tsx` (toggle button).
🎯 Why: To improve accessibility for screen readers, providing clear context for interactive UI elements that lack text content.
♿ Accessibility: Ensures that users relying on screen readers can understand the purpose of these buttons.

---
*PR created automatically by Jules for task [758519579133580723](https://jules.google.com/task/758519579133580723) started by @njtan142*