### PR TITLE
🎨 Palette: [Search Form Clear Button UX improvement]

### DIFF
--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -1,5 +1,6 @@
+import { useRef } from "react"
 import type React from "react"
-import { Search } from "lucide-react"
+import { Search, X } from "lucide-react"
 
 import { Label } from "@/components/ui/shadcn/label"
 import { SidebarGroup, SidebarGroupContent, SidebarInput } from "@/components/ui/sidebar"
@@ -21,21 +22,40 @@ interface SearchFormProps extends React.ComponentProps<"form"> {
  * ```
  */
 export function SearchForm({ value, onSearchChange, ...props }: SearchFormProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleClear = () => {
+    onSearchChange?.("")
+    inputRef.current?.focus()
+  }
+
   return (
     <form {...props} onSubmit={(e) => e.preventDefault()}>
       <SidebarGroup className="py-0">
-        <SidebarGroupContent className="relative">
+        <SidebarGroupContent className="relative group">
           <Label htmlFor="search" className="sr-only">
             Search
           </Label>
           <SidebarInput 
             id="search" 
+            ref={inputRef}
             placeholder="Search ideas..." 
-            className="pl-8" 
+            className="pl-8 pr-8"
             value={value}
             onChange={(e) => onSearchChange?.(e.target.value)}
           />
           <Search className="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 opacity-50 select-none" />
+
+          {value && (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm opacity-70 hover:opacity-100 transition-opacity"
+              aria-label="Clear search"
+            >
+              <X className="size-4" />
+            </button>
+          )}
         </SidebarGroupContent>
       </SidebarGroup>
     </form>

--- a/src/tests/components/search-form.test.tsx
+++ b/src/tests/components/search-form.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SearchForm } from '../../components/search-form'
+import { SidebarProvider } from '../../components/ui/sidebar'
+import { describe, it, expect, vi } from 'vitest'
+
+describe('SearchForm', () => {
+  it('renders correctly with placeholder', () => {
+    render(
+      <SidebarProvider>
+        <SearchForm />
+      </SidebarProvider>
+    )
+    expect(screen.getByPlaceholderText('Search ideas...')).toBeInTheDocument()
+  })
+
+  it('does not render clear button when empty', () => {
+    render(
+      <SidebarProvider>
+        <SearchForm value="" />
+      </SidebarProvider>
+    )
+    expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument()
+  })
+
+  it('renders clear button when value is provided', () => {
+    render(
+      <SidebarProvider>
+        <SearchForm value="test search" />
+      </SidebarProvider>
+    )
+    expect(screen.getByLabelText('Clear search')).toBeInTheDocument()
+  })
+
+  it('calls onSearchChange when clear button is clicked', async () => {
+    const handleSearchChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <SidebarProvider>
+        <SearchForm value="test search" onSearchChange={handleSearchChange} />
+      </SidebarProvider>
+    )
+
+    const clearButton = screen.getByLabelText('Clear search')
+    await user.click(clearButton)
+
+    expect(handleSearchChange).toHaveBeenCalledWith('')
+  })
+})


### PR DESCRIPTION
💡 **What:** Added an accessible "Clear search" (`X`) button to the `SearchForm` component that appears only when the user has typed something.

🎯 **Why:** To make it easier for users to quickly reset their search query. Previously, users had to manually backspace or highlight and delete their query. Now it's a single click (or keypress).

📸 **Before/After:** Before, the input had no clear button. Now, an X button appears gracefully on the right side of the input (without overlapping text thanks to padding adjustments) when there is text. Clicking it clears the text and refocuses the input so the user can immediately type again.

♿ **Accessibility:** The new button has an explicit `aria-label="Clear search"` for screen readers, uses `type="button"` so it doesn't accidentally submit the form, and manages focus by programmatically returning it to the `<input>` element immediately after clearing the text, ensuring a smooth keyboard navigation experience.

---
*PR created automatically by Jules for task [3941329540121309987](https://jules.google.com/task/3941329540121309987) started by @njtan142*