### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in chat messages endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Missing Ownership Verification on Chat Messages Endpoint
+**Vulnerability:** IDOR (Insecure Direct Object Reference) in `getMessagesHandler` for `/api/chats/:id/messages` where any user (or unauthenticated visitor) could fetch the full message history for any `chatId`.
+**Learning:** Handlers reading direct IDs without an explicit `requireAuth` middleware must parse the `Authorization` token and query the related parent object (`chats` table) to verify `user_id == authenticated_user_id`. Simply querying the messages by `chat_id` exposes all messages since there's no inherent user relation on the messages request itself.
+**Prevention:** Always verify object ownership before executing a query that fetches its children. For Hono routes that aren't wrapped in `requireAuth`, enforce authentication in the handler manually and validate the object belongs to the decoded token's user.

--- a/src/worker/handlers/messages.ts
+++ b/src/worker/handlers/messages.ts
@@ -1,10 +1,36 @@
 import { Context } from 'hono';
 import { getSupabase, SupabaseEnv } from '../lib/supabase';
 import { Env } from '../types/env';
+import { getUserIdFromToken } from '../lib/auth-utils';
 
 export async function getMessagesHandler(c: Context<{ Bindings: Env & SupabaseEnv }>) {
     const chatId = c.req.param("id");
     const supabase = getSupabase(c.env);
+
+    // Get userId from Authorization header
+    const authHeader = c.req.header('Authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+        return c.json({ error: "Authentication required" }, 401);
+    }
+
+    const userId = await getUserIdFromToken(token, c.env.SUPABASE_JWT_SECRET);
+    if (!userId) {
+        return c.json({ error: "Invalid token" }, 401);
+    }
+
+    // Verify chat exists and belongs to the authenticated user (prevent IDOR)
+    const { data: chatData, error: chatError } = await supabase
+        .from("chats")
+        .select("id")
+        .eq("id", chatId)
+        .eq("user_id", userId)
+        .single();
+
+    if (chatError || !chatData) {
+        return c.json({ error: "Chat not found or unauthorized" }, 404);
+    }
 
     const { data, error } = await supabase
         .from("messages")


### PR DESCRIPTION
Fixed a critical Insecure Direct Object Reference (IDOR) vulnerability in the `/api/chats/:id/messages` endpoint (`getMessagesHandler` in `src/worker/handlers/messages.ts`).

Previously, the handler queried messages by `chat_id` without verifying if the requested chat belonged to the authenticated user. This allowed any user (or unauthenticated visitor) to access the full message history of any chat ID. 

The fix:
1. Validates the `Authorization` header to extract the authenticated `userId`.
2. Queries the `chats` table to verify the requested `chatId` is owned by the `userId`.
3. Returns appropriate 401/404 errors securely if unauthorized.
4. Added the critical finding to `.jules/sentinel.md` as required.

---
*PR created automatically by Jules for task [13871294948281535146](https://jules.google.com/task/13871294948281535146) started by @njtan142*