### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in Chat interface

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2026-03-09 - ARIA labels for dynamic elements
-**Learning:** For interactive UI elements created in loops (like star ratings), dynamic `aria-label`s (e.g. `aria-label={`Rate ${star} out of 5 stars`}`) provide critical context for screen readers that static text cannot.
-**Action:** Always verify that interactive map-generated components have clear, context-aware `aria-label` attributes.
+## 2024-03-15 - Missing ARIA labels on Icon-only Chat Buttons
+**Learning:** Found that the main Chat interface uses `size="icon"` buttons for Rating (Thumbs Up/Down) and Auto-Scroll (Arrow Down) without any `aria-label` attributes. This pattern might exist in other complex conversational UI components where icons seem self-explanatory to visual users but lack semantic meaning for screen readers.
+**Action:** When adding icon-only control buttons, especially inside complex iterative components like message lists or chat forms, always ensure `aria-label` is provided explicitly. Added a `chat-ux.test.tsx` file to enforce presence of these specific labels to prevent future regressions.

--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -244,6 +244,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-up")}
+            aria-label="Rate response thumbs up"
           >
             <ThumbsUp className="h-4 w-4" />
           </Button>
@@ -252,6 +253,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-down")}
+            aria-label="Rate response thumbs down"
           >
             <ThumbsDown className="h-4 w-4" />
           </Button>
@@ -366,6 +368,7 @@ export function ChatMessages({
               className="pointer-events-auto h-8 w-8 rounded-full ease-in-out animate-in fade-in-0 slide-in-from-bottom-1"
               size="icon"
               variant="ghost"
+              aria-label="Scroll to bottom"
             >
               <ArrowDown className="h-4 w-4" />
             </Button>

--- a/src/tests/components/ui/chat-ux.test.tsx
+++ b/src/tests/components/ui/chat-ux.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Chat } from '../../../../src/components/ui/chat';
+
+// Need to mock user event & UI components
+vi.mock('@/components/ui/shadcn/button', () => ({
+  Button: ({ children, 'aria-label': ariaLabel, onClick, ...props }: any) => (
+    <button aria-label={ariaLabel} onClick={onClick} {...props}>
+      {children}
+    </button>
+  )
+}));
+
+vi.mock('@/components/ui/copy-button', () => ({
+  CopyButton: () => <button>Copy</button>
+}));
+
+vi.mock('@/components/ui/message-input', () => ({
+  MessageInput: () => <div>MessageInput</div>
+}));
+
+vi.mock('@/components/ui/message-list', () => ({
+  MessageList: ({ messageOptions, messages }: any) => (
+    <div>
+      {messages.map((m: any) => (
+        <div key={m.id}>
+          {m.content}
+          {messageOptions(m).actions}
+        </div>
+      ))}
+    </div>
+  )
+}));
+
+vi.mock('@/hooks/use-auto-scroll', () => ({
+  useAutoScroll: () => ({
+    containerRef: { current: null },
+    scrollToBottom: vi.fn(),
+    handleScroll: vi.fn(),
+    shouldAutoScroll: false, // Force showing the scroll to bottom button
+    handleTouchStart: vi.fn()
+  })
+}));
+
+describe('Chat UX', () => {
+  it('should render rating buttons with correct aria-labels', () => {
+    const messages = [{ id: '1', role: 'assistant', content: 'test msg' } as any];
+    const onRateResponse = vi.fn();
+
+    render(
+      <Chat
+        messages={messages}
+        input=""
+        handleInputChange={() => {}}
+        handleSubmit={() => {}}
+        isGenerating={false}
+        onRateResponse={onRateResponse}
+      />
+    );
+
+    expect(screen.getByLabelText('Rate response thumbs up')).toBeInTheDocument();
+    expect(screen.getByLabelText('Rate response thumbs down')).toBeInTheDocument();
+  });
+
+  it('should render scroll to bottom button with correct aria-label', () => {
+    const messages = [{ id: '1', role: 'user', content: 'test msg' } as any];
+
+    render(
+      <Chat
+        messages={messages}
+        input=""
+        handleInputChange={() => {}}
+        handleSubmit={() => {}}
+        isGenerating={false}
+      />
+    );
+
+    expect(screen.getByLabelText('Scroll to bottom')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
💡 **What:** Added `aria-label`s to the icon-only "Thumbs Up", "Thumbs Down", and "Scroll to bottom" buttons in the Chat component. Also added a `chat-ux.test.tsx` file to guarantee these buttons remain labeled.

🎯 **Why:** To make the core Chat interface fully accessible. Screen reader users previously heard "button" without context when navigating to the rating or scroll controls, making the chat un-navigable and difficult to use correctly.

♿ **Accessibility:**
- Voiceover will now accurately announce "Rate response thumbs up", "Rate response thumbs down", and "Scroll to bottom" on focus.

---
*PR created automatically by Jules for task [16431207225814916166](https://jules.google.com/task/16431207225814916166) started by @njtan142*