### PR TITLE
🎨 Palette: Add ARIA labels to Chat icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-09 - ARIA labels for dynamic elements
 **Learning:** For interactive UI elements created in loops (like star ratings), dynamic `aria-label`s (e.g. `aria-label={`Rate ${star} out of 5 stars`}`) provide critical context for screen readers that static text cannot.
 **Action:** Always verify that interactive map-generated components have clear, context-aware `aria-label` attributes.
+
+## 2026-03-09 - Accessible Icon Buttons in Chat Component
+**Learning:** Icon-only buttons in complex components like `Chat` often lack descriptive `aria-label` attributes, which makes them inaccessible for screen-reader users and impacts overall usability.
+**Action:** Proactively identify and add descriptive `aria-label` attributes to all icon-only buttons to enhance accessibility.

--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -244,6 +244,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-up")}
+            aria-label="Rate response thumbs up"
           >
             <ThumbsUp className="h-4 w-4" />
           </Button>
@@ -252,6 +253,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-down")}
+            aria-label="Rate response thumbs down"
           >
             <ThumbsDown className="h-4 w-4" />
           </Button>
@@ -366,6 +368,7 @@ export function ChatMessages({
               className="pointer-events-auto h-8 w-8 rounded-full ease-in-out animate-in fade-in-0 slide-in-from-bottom-1"
               size="icon"
               variant="ghost"
+              aria-label="Scroll to bottom"
             >
               <ArrowDown className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "Thumbs Up", "Thumbs Down", and "Scroll to Bottom" buttons in the Chat component.
🎯 Why: These icon-only buttons lacked textual descriptions, making them inaccessible to screen reader users. This enhancement ensures all users can understand and interact with these controls.
📸 Before/After: Visuals remain exactly the same (no CSS changes), but the underlying HTML is now semantic and accessible.
♿ Accessibility: Improved screen reader support for rating interactions and auto-scrolling.

---
*PR created automatically by Jules for task [12994170052266501946](https://jules.google.com/task/12994170052266501946) started by @njtan142*