### PR TITLE
⚡ Bolt: Optimize N+1 queries in search history analytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-09 - AppSidebar Unnecessary Recalculations
 **Learning:** React sidebars that manage their own local state (like editing states) and also filter parent-provided arrays (like `items`) must memoize the filtering operation, otherwise every local state change triggers an O(N) recalculation.
 **Action:** Always wrap array filtering and derived object creation in `useMemo` when they depend on props in a component that frequently re-renders due to unrelated local state changes.
+
+## 2024-03-24 - N+1 Promises over Network Boundaries (D1/SQLite)
+**Learning:** Using `Promise.all` to execute parameterized SQL queries in a loop creates an N+1 performance bottleneck. In this codebase's architecture (Cloudflare D1), network round-trips for each DB call are exceptionally expensive compared to local SQLite.
+**Action:** When fetching related top-N records for multiple entities (e.g. top 3 search results for 20 search queries), replace `Promise.all` loops with a single batched query using Common Table Expressions (CTEs) and the `ROW_NUMBER() OVER (PARTITION BY ...)` window function. Then group the data in memory. This drastically reduces network calls (from N+1 to 2).

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -316,42 +316,71 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
+      const queryResults = result.results || [];
+      if (queryResults.length === 0) {
+        return [];
+      }
+
+      // ⚡ Bolt Performance Optimization: Batched Top Results Query
+      // What: Replaced an N+1 query pattern in a Promise.all loop with a single CTE query
+      // Why: Fetching top results for up to 20 queries individually creates 20 database
+      //      round-trips. This was a severe bottleneck over network boundaries (D1).
+      // Impact: Reduces DB calls from up to 21 down to exactly 2.
+      const searchQueries = queryResults.map((r: any) => r.search_query);
+      const queryPlaceholders = searchQueries.map(() => '?').join(', ');
+
+      let topResultsQuery = `
+        WITH RankedResults AS (
+          SELECT
+            ss.search_query,
+            sr.result_title,
+            sr.relevance_score,
+            sr.added_to_library,
+            ROW_NUMBER() OVER (
+              PARTITION BY ss.search_query
+              ORDER BY sr.relevance_score DESC
+            ) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.user_id = ?
+            AND ss.search_query IN (${queryPlaceholders})
             ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+        )
+        SELECT * FROM RankedResults
+        WHERE rn <= 3
+        ORDER BY search_query, rn ASC
+      `;
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      const topResultsParams = [userId, ...searchQueries];
+      if (conversationId) {
+        topResultsParams.push(conversationId);
+      }
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      const batchedTopResults = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      // Group results by search query in memory
+      const topResultsByQuery = new Map<string, any[]>();
+      for (const r of (batchedTopResults.results || [])) {
+        const q = r.search_query;
+        if (!topResultsByQuery.has(q)) {
+          topResultsByQuery.set(q, []);
+        }
+        topResultsByQuery.get(q)!.push({
+          title: r.result_title,
+          relevanceScore: r.relevance_score,
+          addedToLibrary: !!r.added_to_library
+        });
+      }
+
+      const queryAnalytics = queryResults.map((row: any) => ({
+        query: row.search_query,
+        searchCount: row.search_count,
+        averageResults: row.avg_results || 0,
+        successRate: row.success_rate || 0,
+        averageProcessingTime: row.avg_processing_time || 0,
+        lastUsed: new Date(row.last_used),
+        topResults: topResultsByQuery.get(row.search_query) || []
+      }));
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
💡 What: Replaced an N+1 query pattern inside a `Promise.all` loop with a single batched CTE query utilizing `ROW_NUMBER() OVER (PARTITION BY ...)` window functions to fetch the top 3 results for multiple top search queries in one go. Grouping is now done in memory.

🎯 Why: Fetching top results for up to 20 queries individually created 20 unnecessary database round-trips. In a Cloudflare Worker/D1 environment where network round-trips to the DB are expensive, this caused a significant performance bottleneck.

📊 Impact: Reduces DB calls from up to 21 down to exactly 2, drastically improving the response time of `getQueryPerformanceAnalytics`.

🔬 Measurement: Review network traces for DB queries when fetching search performance analytics; the queries for top results are now batched into a single execution. Check that the `.jules/bolt.md` file correctly tracks this learning.

---
*PR created automatically by Jules for task [14654902323590377885](https://jules.google.com/task/14654902323590377885) started by @njtan142*