### PR TITLE
🎨 Palette: Add ARIA labels to chat icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-09 - ARIA labels for dynamic elements
 **Learning:** For interactive UI elements created in loops (like star ratings), dynamic `aria-label`s (e.g. `aria-label={`Rate ${star} out of 5 stars`}`) provide critical context for screen readers that static text cannot.
 **Action:** Always verify that interactive map-generated components have clear, context-aware `aria-label` attributes.
+
+## 2026-03-10 - ARIA Labels for Icon-Only Buttons in Complex Components
+**Learning:** Icon-only buttons embedded deep within complex, dynamic components (like message lists or chat histories) are frequently overlooked when adding accessibility features, compared to static forms.
+**Action:** When working with or reviewing complex UI components, explicitly scan for and ensure all icon-only buttons have descriptive `aria-label` attributes for screen reader support.

--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -243,6 +243,7 @@ export function Chat({
             size="icon"
             variant="ghost"
             className="h-6 w-6"
+            aria-label="Rate response thumbs up"
             onClick={() => onRateResponse(message.id, "thumbs-up")}
           >
             <ThumbsUp className="h-4 w-4" />
@@ -251,6 +252,7 @@ export function Chat({
             size="icon"
             variant="ghost"
             className="h-6 w-6"
+            aria-label="Rate response thumbs down"
             onClick={() => onRateResponse(message.id, "thumbs-down")}
           >
             <ThumbsDown className="h-4 w-4" />
@@ -366,6 +368,7 @@ export function ChatMessages({
               className="pointer-events-auto h-8 w-8 rounded-full ease-in-out animate-in fade-in-0 slide-in-from-bottom-1"
               size="icon"
               variant="ghost"
+              aria-label="Scroll to bottom"
             >
               <ArrowDown className="h-4 w-4" />
             </Button>

--- a/verify.html
+++ b/verify.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chat Component Verification</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/verify.tsx"></script>
+  </body>
+</html>

--- a/verify.tsx
+++ b/verify.tsx
@@ -1,0 +1,25 @@
+import { createRoot } from "react-dom/client";
+import { Chat } from "../src/components/ui/chat";
+import { TooltipProvider } from "../src/components/ui/shadcn/tooltip";
+
+const root = createRoot(document.getElementById("root")!);
+
+const mockMessages = [
+  { id: "1", role: "user", content: "Hello!" },
+  { id: "2", role: "assistant", content: "Hi! How can I help you today?" }
+];
+
+root.render(
+  <TooltipProvider>
+    <div style={{ height: "600px", width: "800px", border: "1px solid black", padding: "16px" }}>
+      <Chat
+        messages={mockMessages}
+        input=""
+        handleInputChange={() => {}}
+        handleSubmit={() => {}}
+        isGenerating={false}
+        onRateResponse={(id, rating) => console.log(id, rating)}
+      />
+    </div>
+  </TooltipProvider>
+);


### PR DESCRIPTION
## What
Added `aria-label` attributes to the icon-only buttons in `src/components/ui/chat.tsx` (ThumbsUp, ThumbsDown, and ArrowDown/Scroll to bottom).

## Why
Icon-only buttons are inaccessible to screen readers without text alternatives. Adding these `aria-label`s makes the chat interface more usable for assistive technologies.

## Before/After
No visual changes.

## Accessibility
Added "Rate response thumbs up", "Rate response thumbs down", and "Scroll to bottom" `aria-label` attributes to the respective icon buttons.

---
*PR created automatically by Jules for task [6256172774970153212](https://jules.google.com/task/6256172774970153212) started by @njtan142*