### PR TITLE
⚡ Bolt: Bulk insert search results for performance improvements

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-09 - AppSidebar Unnecessary Recalculations
 **Learning:** React sidebars that manage their own local state (like editing states) and also filter parent-provided arrays (like `items`) must memoize the filtering operation, otherwise every local state change triggers an O(N) recalculation.
 **Action:** Always wrap array filtering and derived object creation in `useMemo` when they depend on props in a component that frequently re-renders due to unrelated local state changes.
+
+## 2024-06-18 - [Fix N+1 query issue for Search Results Analytics]
+**Learning:** In Cloudflare Workers using Supabase, calling single row inserts in a `Promise.all` or sequential loop creates a severe N+1 query issue, leading to poor performance and unnecessary network round trips when recording search results for analytics.
+**Action:** Always implement and use bulk insert methods (like `recordSearchResults`) that utilize `supabase.from('table').insert(arrayOfRecords)` to insert all records in a single database round trip.

--- a/src/worker/lib/search-analytics-manager.ts
+++ b/src/worker/lib/search-analytics-manager.ts
@@ -169,6 +169,55 @@ export class SearchAnalyticsManager {
   }
 
   /**
+   * Record multiple search results in a single operation
+   * This is much more efficient than calling recordSearchResult in a loop
+   */
+  async recordSearchResults(resultsData: Array<Omit<SearchResult, 'id' | 'createdAt'>>): Promise<string[]> {
+    if (!resultsData || resultsData.length === 0) return [];
+
+    try {
+      const supabase = getSupabase(this.env);
+
+      const recordsToInsert = resultsData.map(data => ({
+        id: crypto.randomUUID(),
+        search_session_id: data.searchSessionId,
+        reference_id: data.referenceId || null,
+        result_title: data.resultTitle,
+        result_authors: data.resultAuthors,
+        result_journal: data.resultJournal || null,
+        result_year: data.resultYear || null,
+        result_doi: data.resultDoi || null,
+        result_url: data.resultUrl || null,
+        relevance_score: data.relevanceScore,
+        confidence_score: data.confidenceScore,
+        quality_score: data.qualityScore,
+        citation_count: data.citationCount,
+        user_action: data.userAction || null,
+        user_feedback_rating: data.userFeedbackRating || null,
+        user_feedback_comments: data.userFeedbackComments || null,
+        added_to_library: data.addedToLibrary,
+        added_at: data.addedAt?.toISOString() || null
+      }));
+
+      const { error } = await supabase
+        .from('search_results')
+        .insert(recordsToInsert);
+
+      if (error) {
+        console.error('Error recording multiple search results:', error);
+        throw error;
+      }
+
+      const resultIds = recordsToInsert.map(r => r.id);
+      console.log(`Recorded ${resultIds.length} search results in bulk`);
+      return resultIds;
+    } catch (error) {
+      console.error('Error recording multiple search results:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Record a search result interaction
    */
   async recordSearchResult(resultData: Omit<SearchResult, 'id' | 'createdAt'>): Promise<string> {

--- a/src/worker/services/search-service.ts
+++ b/src/worker/services/search-service.ts
@@ -476,22 +476,24 @@ export class SearchService {
       if (sessionId && env) {
         try {
           const analyticsManager = this.getAnalyticsManager(env);
-          for (const result of finalResults) {
-            await analyticsManager.recordSearchResult({
-              searchSessionId: sessionId,
-              resultTitle: result.title,
-              resultAuthors: result.authors,
-              resultJournal: result.journal,
-              resultYear: result.publication_date ? parseInt(result.publication_date) : undefined,
-              resultDoi: result.doi,
-              resultUrl: result.url,
-              relevanceScore: result.relevance_score || 0,
-              confidenceScore: result.confidence || 0,
-              qualityScore: this.calculateQualityScore(result),
-              citationCount: result.citation_count || 0,
-              addedToLibrary: false,
-            });
-          }
+
+          // Bulk insert results to avoid N+1 queries
+          const resultsToRecord = finalResults.map(result => ({
+            searchSessionId: sessionId,
+            resultTitle: result.title,
+            resultAuthors: result.authors,
+            resultJournal: result.journal,
+            resultYear: result.publication_date ? parseInt(result.publication_date) : undefined,
+            resultDoi: result.doi,
+            resultUrl: result.url,
+            relevanceScore: result.relevance_score || 0,
+            confidenceScore: result.confidence || 0,
+            qualityScore: this.calculateQualityScore(result),
+            citationCount: result.citation_count || 0,
+            addedToLibrary: false,
+          }));
+
+          await analyticsManager.recordSearchResults(resultsToRecord);
 
           const processingTime = Date.now() - startTime;
           await this.updateSearchSession(env, sessionId, {


### PR DESCRIPTION
💡 **What:** Added a new bulk insertion method `recordSearchResults` to `SearchAnalyticsManager` that leverages Supabase's native array insertion capability to insert all generated search results in one go. Refactored the analytics recording loop in `SearchService` to use this new bulk method instead of calling `recordSearchResult` iteratively.

🎯 **Why:** Previously, the code iterated over the `finalResults` array and executed an independent `INSERT` operation to Supabase for every single search result. This creates a severe N+1 query issue, multiplying latency, unnecessary network round-trips, and dramatically slowing down search resolution times.

📊 **Impact:** Reduces database insertions for recording search analytics from O(N) (where N is the number of results, typically 10-20) to exactly O(1) single bulk insert. This will shave considerable ms off response time, especially notable over remote Cloudflare Worker connections.

🔬 **Measurement:** Code correctly maps the data arrays in memory and sends them en-masse. Verified via the comprehensive `SearchService` testing suite (`pnpm test src/worker/services/__tests__/search-service.test.ts`), and the patch passes safely without regressions. Tested in the JSDoc output/linting process as well.

---
*PR created automatically by Jules for task [17540051858919765483](https://jules.google.com/task/17540051858919765483) started by @njtan142*