### PR TITLE
⚡ Bolt: Use bulk insert for search analytics to avoid N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-03-09 - AppSidebar Unnecessary Recalculations
 **Learning:** React sidebars that manage their own local state (like editing states) and also filter parent-provided arrays (like `items`) must memoize the filtering operation, otherwise every local state change triggers an O(N) recalculation.
 **Action:** Always wrap array filtering and derived object creation in `useMemo` when they depend on props in a component that frequently re-renders due to unrelated local state changes.
+
+## 2026-03-19 - Supabase N+1 Queries during Analytics Insert
+**Learning:** Iterating over arrays (like search results) and performing individual `supabase.from('table').insert()` operations causes severe N+1 query bottlenecks in Cloudflare Workers.
+**Action:** Always map the data array beforehand with pre-generated UUIDs and use a single `supabase.from('table').insert(arrayOfRecords)` call for bulk insertions.

--- a/src/worker/lib/search-analytics-manager.ts
+++ b/src/worker/lib/search-analytics-manager.ts
@@ -169,6 +169,61 @@ export class SearchAnalyticsManager {
   }
 
   /**
+   * Record multiple search result interactions in bulk
+   * ⚡ BOLT OPTIMIZATION:
+   * What: Bulk insert for search results instead of sequential single inserts
+   * Why: Prevents N+1 query problems and significantly reduces database roundtrips
+   * Impact: O(1) database queries instead of O(N) where N is the number of results
+   */
+  async recordSearchResults(resultsData: Omit<SearchResult, 'id' | 'createdAt'>[]): Promise<string[]> {
+    if (!resultsData || resultsData.length === 0) return [];
+
+    try {
+      const supabase = getSupabase(this.env);
+
+      const insertData = resultsData.map(resultData => {
+        const resultId = crypto.randomUUID();
+        return {
+          id: resultId,
+          search_session_id: resultData.searchSessionId,
+          reference_id: resultData.referenceId || null,
+          result_title: resultData.resultTitle,
+          result_authors: resultData.resultAuthors,
+          result_journal: resultData.resultJournal || null,
+          result_year: resultData.resultYear || null,
+          result_doi: resultData.resultDoi || null,
+          result_url: resultData.resultUrl || null,
+          relevance_score: resultData.relevanceScore,
+          confidence_score: resultData.confidenceScore,
+          quality_score: resultData.qualityScore,
+          citation_count: resultData.citationCount,
+          user_action: resultData.userAction || null,
+          user_feedback_rating: resultData.userFeedbackRating || null,
+          user_feedback_comments: resultData.userFeedbackComments || null,
+          added_to_library: resultData.addedToLibrary,
+          added_at: resultData.addedAt?.toISOString() || null
+        };
+      });
+
+      const { error } = await supabase
+        .from('search_results')
+        .insert(insertData);
+
+      if (error) {
+        console.error('Error recording search results in bulk:', error);
+        throw error;
+      }
+
+      const resultIds = insertData.map(data => data.id);
+      console.log(`Bulk search results recorded: ${resultIds.length} items`);
+      return resultIds;
+    } catch (error) {
+      console.error('Error recording search results in bulk:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Record a search result interaction
    */
   async recordSearchResult(resultData: Omit<SearchResult, 'id' | 'createdAt'>): Promise<string> {

--- a/src/worker/services/search-service.ts
+++ b/src/worker/services/search-service.ts
@@ -473,24 +473,29 @@ export class SearchService {
       }
 
       // Record search results for analytics
+      // ⚡ BOLT OPTIMIZATION:
+      // What: Using recordSearchResults bulk insert instead of individual recordSearchResult inserts
+      // Why: Eliminates N+1 query problem, replacing sequential network requests with a single roundtrip
       if (sessionId && env) {
         try {
           const analyticsManager = this.getAnalyticsManager(env);
-          for (const result of finalResults) {
-            await analyticsManager.recordSearchResult({
-              searchSessionId: sessionId,
-              resultTitle: result.title,
-              resultAuthors: result.authors,
-              resultJournal: result.journal,
-              resultYear: result.publication_date ? parseInt(result.publication_date) : undefined,
-              resultDoi: result.doi,
-              resultUrl: result.url,
-              relevanceScore: result.relevance_score || 0,
-              confidenceScore: result.confidence || 0,
-              qualityScore: this.calculateQualityScore(result),
-              citationCount: result.citation_count || 0,
-              addedToLibrary: false,
-            });
+          const resultsToRecord = finalResults.map(result => ({
+            searchSessionId: sessionId,
+            resultTitle: result.title,
+            resultAuthors: result.authors,
+            resultJournal: result.journal,
+            resultYear: result.publication_date ? parseInt(result.publication_date) : undefined,
+            resultDoi: result.doi,
+            resultUrl: result.url,
+            relevanceScore: result.relevance_score || 0,
+            confidenceScore: result.confidence || 0,
+            qualityScore: this.calculateQualityScore(result),
+            citationCount: result.citation_count || 0,
+            addedToLibrary: false,
+          }));
+
+          if (resultsToRecord.length > 0) {
+            await analyticsManager.recordSearchResults(resultsToRecord);
           }
 
           const processingTime = Date.now() - startTime;


### PR DESCRIPTION
💡 **What:** 
Created a new `recordSearchResults` method in `SearchAnalyticsManager` that leverages Supabase's bulk insert capability (`supabase.from().insert(arrayOfRecords)`). Modified `SearchService.search` to use this new method instead of iterating over the `finalResults` array and calling `recordSearchResult` individually.

🎯 **Why:**
The previous implementation used a `for...of` loop to insert tracking data for each individual search result one by one. In a Cloudflare Worker interacting with a remote database like Supabase, this sequential network behavior creates an N+1 query bottleneck. By grouping these insertions into a single network payload, the application avoids redundant roundtrips.

📊 **Impact:**
Significantly reduces database roundtrips from O(N) (where N is the number of filtered search results, typically 10-20 per search request) to O(1). This should yield a substantial improvement in overall response time for the `/search` endpoint by eliminating sequential database latency.

🔬 **Measurement:**
This can be verified by observing the `processingTimeMs` metrics on search sessions, or by monitoring Cloudflare Worker execution times and Supabase query logs for the `search_results` table before and after the change.

---
*PR created automatically by Jules for task [16428381746535048676](https://jules.google.com/task/16428381746535048676) started by @njtan142*