### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in messages endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - IDOR Vulnerability in Chat Messages Endpoint
+**Vulnerability:** The `/api/chats/:id/messages` endpoint retrieved all messages for a given `chatId` without verifying that the `chatId` belonged to the authenticated user.
+**Learning:** Even if the client-side UI only displays chats belonging to the user, the backend API must explicitly re-validate ownership of the resource being requested to prevent Insecure Direct Object Reference (IDOR) attacks where a malicious user could guess or enumerate `chatId`s.
+**Prevention:** Always extract the user context (e.g., from a JWT token) and include it in database queries when accessing user-owned resources (e.g., `eq('user_id', userId)`).

--- a/src/worker/handlers/messages.ts
+++ b/src/worker/handlers/messages.ts
@@ -1,10 +1,36 @@
 import { Context } from 'hono';
 import { getSupabase, SupabaseEnv } from '../lib/supabase';
 import { Env } from '../types/env';
+import { getUserIdFromToken } from '../lib/auth-utils';
 
 export async function getMessagesHandler(c: Context<{ Bindings: Env & SupabaseEnv }>) {
     const chatId = c.req.param("id");
     const supabase = getSupabase(c.env);
+
+    // SECURITY: Authenticate request
+    const authHeader = c.req.header('Authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+        return c.json({ error: "Authentication required" }, 401);
+    }
+
+    const userId = await getUserIdFromToken(token, c.env.SUPABASE_JWT_SECRET);
+    if (!userId) {
+        return c.json({ error: "Invalid token" }, 401);
+    }
+
+    // SECURITY: Verify chat belongs to authenticated user to prevent IDOR
+    const { data: chatData, error: chatError } = await supabase
+        .from("chats")
+        .select("id")
+        .eq("id", chatId)
+        .eq("user_id", userId)
+        .single();
+
+    if (chatError || !chatData) {
+        return c.json({ error: "Chat not found or access denied." }, 403);
+    }
 
     const { data, error } = await supabase
         .from("messages")


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/api/chats/:id/messages` endpoint retrieved all messages for a given `chatId` without verifying that the `chatId` actually belonged to the authenticated user. This led to an Insecure Direct Object Reference (IDOR) vulnerability where a user could enumerate other users' chat IDs and read their messages.
🎯 **Impact:** Unauthorized users could access the message contents of other users' conversations.
🔧 **Fix:** Added token verification using `getUserIdFromToken` to authenticate the user, and applied a query to the `chats` table to check if the `chatId` belongs to the `userId`. If the check fails, the handler responds with a `401 Unauthorized` or `403 Forbidden` error depending on the situation.
✅ **Verification:** Verified by ensuring the code passes type checking and tests. Manually confirmed the `user_id` constraint is actively checked before returning messages.

---
*PR created automatically by Jules for task [10837054583807659186](https://jules.google.com/task/10837054583807659186) started by @njtan142*