### PR TITLE
🎨 Palette: Add ARIA labels to chat icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-09 - ARIA labels for dynamic elements
 **Learning:** For interactive UI elements created in loops (like star ratings), dynamic `aria-label`s (e.g. `aria-label={`Rate ${star} out of 5 stars`}`) provide critical context for screen readers that static text cannot.
 **Action:** Always verify that interactive map-generated components have clear, context-aware `aria-label` attributes.
+
+## 2026-03-19 - ARIA labels for chat interface icon buttons
+**Learning:** Shadcn `<Button size="icon">` components frequently omit accessible names, severely impacting accessibility for critical app features like rating and scrolling in chat interfaces where only a Lucide icon is present.
+**Action:** Always append explicit `aria-label`s to any icon-only button to ensure they are properly announced by screen readers.

--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -243,6 +243,7 @@ export function Chat({
             size="icon"
             variant="ghost"
             className="h-6 w-6"
+            aria-label="Rate response thumbs up"
             onClick={() => onRateResponse(message.id, "thumbs-up")}
           >
             <ThumbsUp className="h-4 w-4" />
@@ -251,6 +252,7 @@ export function Chat({
             size="icon"
             variant="ghost"
             className="h-6 w-6"
+            aria-label="Rate response thumbs down"
             onClick={() => onRateResponse(message.id, "thumbs-down")}
           >
             <ThumbsDown className="h-4 w-4" />
@@ -366,6 +368,7 @@ export function ChatMessages({
               className="pointer-events-auto h-8 w-8 rounded-full ease-in-out animate-in fade-in-0 slide-in-from-bottom-1"
               size="icon"
               variant="ghost"
+              aria-label="Scroll to bottom"
             >
               <ArrowDown className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
### 💡 What:
Added explicit `aria-label` attributes to the icon-only buttons in the Chat component:
- `aria-label="Rate response thumbs up"`
- `aria-label="Rate response thumbs down"`
- `aria-label="Scroll to bottom"`

Also added an entry to `.Jules/palette.md` noting the importance of providing accessible names for Shadcn icon-only `<Button>` components.

### 🎯 Why:
To ensure the rating and scrolling features within the chat interface are fully accessible to users relying on screen readers. Previously, these icon-only buttons lacked descriptive text, making their function ambiguous to assistive technologies.

### 📸 Before/After:
*Visual appearance is identical, as expected. Semantic HTML was improved.*

### ♿ Accessibility:
Provides critical context to screen readers for interactive elements that only rely on Lucide icons.

---
*PR created automatically by Jules for task [5961413516191143230](https://jules.google.com/task/5961413516191143230) started by @njtan142*