### PR TITLE
🎨 Palette: Add ARIA labels to chat rating and scroll buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-09 - ARIA labels for dynamic elements
 **Learning:** For interactive UI elements created in loops (like star ratings), dynamic `aria-label`s (e.g. `aria-label={`Rate ${star} out of 5 stars`}`) provide critical context for screen readers that static text cannot.
 **Action:** Always verify that interactive map-generated components have clear, context-aware `aria-label` attributes.
+
+## 2026-03-09 - Missing ARIA labels in dynamic/interactive chat components
+**Learning:** Icon-only buttons in the core Chat component (`src/components/ui/chat.tsx`), particularly actions like "Thumbs up", "Thumbs down", and "Scroll to bottom", were missing `aria-label` attributes. Screen reader users would have no context for what these buttons do since they lack text nodes.
+**Action:** When implementing new features or components with interactive icon-only buttons (`size="icon"`), proactively add descriptive `aria-label` attributes.

--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -244,6 +244,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-up")}
+            aria-label="Rate response as helpful"
           >
             <ThumbsUp className="h-4 w-4" />
           </Button>
@@ -252,6 +253,7 @@ export function Chat({
             variant="ghost"
             className="h-6 w-6"
             onClick={() => onRateResponse(message.id, "thumbs-down")}
+            aria-label="Rate response as unhelpful"
           >
             <ThumbsDown className="h-4 w-4" />
           </Button>
@@ -366,6 +368,7 @@ export function ChatMessages({
               className="pointer-events-auto h-8 w-8 rounded-full ease-in-out animate-in fade-in-0 slide-in-from-bottom-1"
               size="icon"
               variant="ghost"
+              aria-label="Scroll to bottom"
             >
               <ArrowDown className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to three icon-only buttons in the main Chat component (`src/components/ui/chat.tsx`): the positive rating button ("Thumbs up"), negative rating button ("Thumbs down"), and the "Scroll to bottom" arrow button.

🎯 **Why:** These buttons previously contained only an SVG icon (`<ThumbsUp />`, `<ThumbsDown />`, `<ArrowDown />`) with no accessible text node. Screen reader users navigating the chat interface would not receive any context for what these interactive buttons do.

📸 **Before/After:** The visual UI remains completely unchanged, as this is purely a semantic HTML enhancement for assistive technologies.

♿ **Accessibility:**
- Improved screen-reader context for message feedback options.
- Improved screen-reader context for navigating the chat view.
- Follows the existing pattern seen in `message-input.tsx` where icon buttons correctly use `aria-label`.

Also documented this finding in `.Jules/palette.md` to prevent similar issues when dynamically rendering interactive components.

---
*PR created automatically by Jules for task [3251258254410415854](https://jules.google.com/task/3251258254410415854) started by @njtan142*