### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in chat messages endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application is using `origin: '*'` together with `credentials: true` in Hono CORS configuration (`src/worker/routes/auth-routes.ts`).
 **Learning:** Using a wildcard origin with credentials enabled allows any website to make requests to the authenticated endpoints and include the user's cookies/credentials. This is a significant security risk and can lead to CSRF attacks or data theft.
 **Prevention:** Avoid using `origin: '*'` with `credentials: true`. Instead, implement a dynamic origin resolver function utilizing `c.env` or `import.meta.env` to strictly validate against allowed frontend URLs and development environments.
+
+## 2024-06-18 - Missing Authentication and IDOR on Chat Messages
+**Vulnerability:** The `getMessagesHandler` for the `/api/chats/:id/messages` endpoint lacked both authentication and authorization checks. It simply read `chatId` from the route parameters and returned all messages from the database for that chat ID. This Insecure Direct Object Reference (IDOR) allowed any unauthenticated user to read any chat's message history.
+**Learning:** Even if the client-side UI prevents navigation to other users' chats, backend API endpoints must enforce authorization rules independently. Just because a user does not see the IDs of other users' chats does not mean the API is safe from direct requests via `curl` or Postman.
+**Prevention:** For all endpoints exposing user-specific or sensitive data by ID, implement robust authorization: require a valid session/token, extract the authenticated user ID (`getUserIdFromToken`), and assert that the requested resource (e.g., the chat record) actually belongs to that authenticated user before returning its contents.

--- a/src/worker/handlers/messages.ts
+++ b/src/worker/handlers/messages.ts
@@ -1,10 +1,36 @@
 import { Context } from 'hono';
 import { getSupabase, SupabaseEnv } from '../lib/supabase';
 import { Env } from '../types/env';
+import { getUserIdFromToken } from '../lib/auth-utils';
 
 export async function getMessagesHandler(c: Context<{ Bindings: Env & SupabaseEnv }>) {
     const chatId = c.req.param("id");
     const supabase = getSupabase(c.env);
+
+    // Get userId from Authorization header
+    const authHeader = c.req.header('Authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+        return c.json({ error: "Authentication required" }, 401);
+    }
+
+    const userId = await getUserIdFromToken(token, c.env.SUPABASE_JWT_SECRET);
+    if (!userId) {
+        return c.json({ error: "Invalid token" }, 401);
+    }
+
+    // Verify chat exists and belongs to authenticated user to prevent IDOR
+    const { data: chatData, error: chatError } = await supabase
+        .from("chats")
+        .select("id")
+        .eq("id", chatId)
+        .eq("user_id", userId)
+        .single();
+
+    if (chatError || !chatData) {
+        return c.json({ error: "Chat not found or access denied" }, 404);
+    }
 
     const { data, error } = await supabase
         .from("messages")


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `getMessagesHandler` for the `/api/chats/:id/messages` endpoint was entirely missing authentication and authorization. It accepted a `chatId` from the URL parameters and directly queried the database for all messages belonging to that chat, returning them to the requester. This Insecure Direct Object Reference (IDOR) allowed any unauthenticated or authenticated user to read the message history of any chat if they knew or guessed the `chatId`.
🎯 **Impact:** Unauthorized access and complete exposure of private user chat histories to arbitrary attackers.
🔧 **Fix:** Added Hono context `authHeader` verification, extracted the `userId` using `getUserIdFromToken`, and queried the `chats` table to assert that the `chatId` exists and specifically belongs to the authenticated `userId`. If the check fails or authentication is missing, it returns a 401 or 404 response to safely protect the data.
✅ **Verification:** Verified that tests pass via `pnpm test` and the linter functions via `pnpm lint`. Reverted an earlier attempt to apply similar logic to `billing-routes.ts` upon recognizing those endpoints function as internal administrative webhooks where self-escalation would be a more serious logic flaw. Journal updated in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8466998651824951828](https://jules.google.com/task/8466998651824951828) started by @njtan142*