### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-23 - ARIA labels in dynamic edit-mode icon buttons
+**Learning:** Icon-only buttons (like `Save`, `Cancel`, `Edit`, `Regenerate`) rendered dynamically inside list items during edit modes are frequently missed for accessibility annotations because they are not part of the primary static UI. This makes crucial actions completely opaque to screen reader users when managing list items (like editing Idea titles).
+**Action:** Always audit conditional render paths (e.g., `isEditing ? <Save/Cancel> : <Edit>`) for icon-only buttons to ensure they have explicit, context-aware `aria-label` attributes describing the action (e.g., "Save edited title" rather than just "Save").

--- a/src/components/ui/attachment-menu.tsx
+++ b/src/components/ui/attachment-menu.tsx
@@ -371,6 +371,7 @@ function IdeaSelectorDialog({
                           className="h-7 w-7"
                           onClick={(e) => handleSaveEdit(idea, e)}
                           disabled={isUpdating}
+                          aria-label="Save edited title"
                         >
                           {isUpdating ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
@@ -384,6 +385,7 @@ function IdeaSelectorDialog({
                           className="h-7 w-7"
                           onClick={handleCancelEdit}
                           disabled={isUpdating}
+                          aria-label="Cancel editing title"
                         >
                           <X className="h-4 w-4 text-destructive" />
                         </Button>
@@ -405,6 +407,7 @@ function IdeaSelectorDialog({
                           className="h-6 w-6 shrink-0"
                           onClick={(e) => handleStartEdit(idea, e)}
                           title="Edit title"
+                          aria-label="Edit idea title"
                         >
                           <Pencil className="h-3 w-3" />
                         </Button>
@@ -415,6 +418,7 @@ function IdeaSelectorDialog({
                           onClick={(e) => handleRegenerateTitle(idea, e)}
                           disabled={regeneratingId === idea.id || !idea.description}
                           title="Regenerate title with AI"
+                          aria-label="Regenerate idea title with AI"
                         >
                           {regeneratingId === idea.id ? (
                             <Loader2 className="h-3 w-3 animate-spin" />

--- a/src/components/ui/tools-panel.tsx
+++ b/src/components/ui/tools-panel.tsx
@@ -53,6 +53,7 @@ export const ToolsPanel: React.FC<ToolsPanelProps> = ({
         variant="ghost"
         size="icon"
         onClick={() => setIsOpen(!isOpen)}
+        aria-label={isOpen ? "Close tools panel" : "Open tools panel"}
         className={cn(
           "absolute top-4 z-10 h-8 w-8 rounded-full border bg-background shadow-sm hover:bg-muted transition-all duration-300",
           isOpen


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to several icon-only `<Button size="icon">` components that were missing them across the UI.

Specifically:
- In `src/components/ui/attachment-menu.tsx`, added labels to the dynamically rendered "Save", "Cancel", "Edit", and "Regenerate" icon buttons for ideas.
- In `src/components/ui/tools-panel.tsx`, added a dynamic label ("Open tools panel" / "Close tools panel") to the sidebar toggle button.

### 🎯 Why
Icon-only buttons rely completely on visual cues (the icon itself) to convey their purpose. Screen readers cannot interpret the visual icon, making these buttons functionally invisible or confusing to users who rely on assistive technologies. Providing an `aria-label` ensures these users understand what action the button performs.

### 📸 Before/After
*No visual changes. This is purely a screen reader accessibility enhancement.*

### ♿ Accessibility
- Improves navigation and understanding for screen reader users by providing explicit text descriptions for critical actions (editing, saving, toggling the tools panel).
- Fixes the issue where dynamically rendered icon buttons during an edit mode (e.g., Save/Cancel) were completely opaque to assistive technologies.

---
*PR created automatically by Jules for task [14606903519665112766](https://jules.google.com/task/14606903519665112766) started by @njtan142*