### PR TITLE
🎨 Palette: [UX improvement] Add aria-labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Missing aria-labels in Dialog component menus
+**Learning:** Icon-only buttons representing primary user actions (Save, Cancel, Edit, and Regenerate) inside nested dynamic components like the `IdeaSelectorDialog` frequently lack `aria-label` attributes in this app. The same applies to floating UI toggles (e.g., Tools Panel sidebar toggle button). Screen reader users would have no context on what these buttons do.
+**Action:** When adding or reviewing deeply nested components like selector dialogs or collapsible sidebars in this design system, I must proactively search for `<Button size="icon">` instances without visible text and ensure they are explicitly labeled with an `aria-label`.

--- a/src/components/ui/attachment-menu.tsx
+++ b/src/components/ui/attachment-menu.tsx
@@ -371,6 +371,7 @@ function IdeaSelectorDialog({
                           className="h-7 w-7"
                           onClick={(e) => handleSaveEdit(idea, e)}
                           disabled={isUpdating}
+                          aria-label="Save title"
                         >
                           {isUpdating ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
@@ -384,6 +385,7 @@ function IdeaSelectorDialog({
                           className="h-7 w-7"
                           onClick={handleCancelEdit}
                           disabled={isUpdating}
+                          aria-label="Cancel editing"
                         >
                           <X className="h-4 w-4 text-destructive" />
                         </Button>
@@ -405,6 +407,7 @@ function IdeaSelectorDialog({
                           className="h-6 w-6 shrink-0"
                           onClick={(e) => handleStartEdit(idea, e)}
                           title="Edit title"
+                          aria-label="Edit title"
                         >
                           <Pencil className="h-3 w-3" />
                         </Button>
@@ -415,6 +418,7 @@ function IdeaSelectorDialog({
                           onClick={(e) => handleRegenerateTitle(idea, e)}
                           disabled={regeneratingId === idea.id || !idea.description}
                           title="Regenerate title with AI"
+                          aria-label="Regenerate title with AI"
                         >
                           {regeneratingId === idea.id ? (
                             <Loader2 className="h-3 w-3 animate-spin" />

--- a/src/components/ui/tools-panel.tsx
+++ b/src/components/ui/tools-panel.tsx
@@ -59,6 +59,7 @@ export const ToolsPanel: React.FC<ToolsPanelProps> = ({
             ? "-left-4" // Center when open
             : "-left-10" // More to the right when closed
         )}
+        aria-label="Toggle tools panel"
       >
         {isOpen ? (
           <ChevronRight className="h-4 w-4" />


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only `<Button size="icon">` components in `src/components/ui/attachment-menu.tsx` (Save, Cancel, Edit, and AI Regenerate buttons within the Idea selector dialog) and in `src/components/ui/tools-panel.tsx` (the toggle button). Also added a corresponding learning entry to `.jules/palette.md`.
🎯 Why: Screen readers depend on explicit labels (like `aria-label`) for elements that lack visible text content. Without them, users navigating via screen readers only hear "button", lacking the context required to understand what action the button performs. This enhances the accessibility of the application.
📸 Before/After: Before, `<Button size="icon">` components lacked `aria-label` attributes in these specific files. After, they have explicit labels defining their action (e.g., "Save title", "Cancel editing", "Toggle tools panel").
♿ Accessibility: Directly improves keyboard and screen reader accessibility by ensuring icon-only interactive controls announce their purpose clearly to assistive technologies.

---
*PR created automatically by Jules for task [13689139152301848943](https://jules.google.com/task/13689139152301848943) started by @njtan142*