### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to icon-only close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-03-09 - Missing ARIA labels in dynamic/interactive chat components
 **Learning:** Icon-only buttons in the core Chat component (`src/components/ui/chat.tsx`), particularly actions like "Thumbs up", "Thumbs down", and "Scroll to bottom", were missing `aria-label` attributes. Screen reader users would have no context for what these buttons do since they lack text nodes.
 **Action:** When implementing new features or components with interactive icon-only buttons (`size="icon"`), proactively add descriptive `aria-label` attributes.
+## 2024-03-25 - Accessibility for Icon-only Close Buttons
+**Learning:** Found an accessibility issue pattern specific to this app: many `Button` components consisting only of an `<X />` icon (used for closing dialogs/panels/forms) lack an `aria-label` attribute, rendering them inaccessible or poorly described by screen readers.
+**Action:** When implementing new panels, dialogs, or forms that require a close button, always ensure an explicit `aria-label` (e.g., `aria-label="Close dialog"`) is provided when using `<Button variant="ghost" size="icon">` or similar icon-only patterns.

--- a/src/components/ui/citation-insertion.tsx
+++ b/src/components/ui/citation-insertion.tsx
@@ -249,7 +249,7 @@ export const CitationInsertion: React.FC<CitationInsertionProps> = ({
             </Badge>
           )}
         </div>
-        <Button variant="ghost" size="sm" onClick={onClose}>
+        <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close dialog">
           <X className="h-4 w-4" />
         </Button>
       </div>

--- a/src/components/ui/content-source-selector.tsx
+++ b/src/components/ui/content-source-selector.tsx
@@ -824,7 +824,7 @@ const ContentPreviewModal: React.FC<ContentPreviewModalProps> = ({
             <Eye className="h-5 w-5" />
             Content Preview: {preview.source.title}
           </h3>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close preview">
             ×
           </Button>
         </div>

--- a/src/components/ui/reference-form.tsx
+++ b/src/components/ui/reference-form.tsx
@@ -229,7 +229,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
           <CardTitle>
             {isEditing ? 'Edit Reference' : 'Add New Reference'}
           </CardTitle>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close form">
             <X className="h-4 w-4" />
           </Button>
         </div>

--- a/src/components/ui/search-history-panel.tsx
+++ b/src/components/ui/search-history-panel.tsx
@@ -344,6 +344,7 @@ export const SearchHistoryPanel: React.FC<SearchHistoryPanelProps> = ({
                 variant="ghost"
                 size="sm"
                 onClick={() => setShowFilters(false)}
+                aria-label="Close filters"
               >
                 <X className="h-4 w-4" />
               </Button>

--- a/src/components/ui/search-result-export.tsx
+++ b/src/components/ui/search-result-export.tsx
@@ -151,7 +151,7 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
               Export Search Results ({results.length} results)
             </CardTitle>
             {onClose && (
-              <Button variant="ghost" size="sm" onClick={onClose}>
+              <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close export dialog">
                 <X className="h-4 w-4" />
               </Button>
             )}

--- a/src/components/ui/search-result-management-panel.tsx
+++ b/src/components/ui/search-result-management-panel.tsx
@@ -220,7 +220,7 @@ export const SearchResultManagementPanel: React.FC<SearchResultManagementPanelPr
                 Refresh
               </Button>
               {onClose && (
-                <Button variant="ghost" size="sm" onClick={onClose}>
+                <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close panel">
                   <X className="h-4 w-4" />
                 </Button>
               )}

--- a/src/components/ui/search-result-sharing.tsx
+++ b/src/components/ui/search-result-sharing.tsx
@@ -150,7 +150,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                 Results Shared Successfully
               </CardTitle>
               {onClose && (
-                <Button variant="ghost" size="sm" onClick={onClose}>
+                <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close share dialog">
                   <X className="h-4 w-4" />
                 </Button>
               )}
@@ -282,7 +282,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
               Share Search Results ({results.length} results)
             </CardTitle>
             {onClose && (
-              <Button variant="ghost" size="sm" onClick={onClose}>
+              <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close share dialog">
                 <X className="h-4 w-4" />
               </Button>
             )}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple `<Button variant="ghost" size="sm">` components that contained only an `<X />` icon.
🎯 Why: Screen readers had no context for these buttons, making dialog, panel, and form dismissals completely inaccessible to assistive technologies.
♿ Accessibility: The buttons now clearly announce their purpose (e.g., "Close dialog", "Close panel", "Close filters") when focused by a screen reader or keyboard navigation.

---
*PR created automatically by Jules for task [6216547543985744393](https://jules.google.com/task/6216547543985744393) started by @njtan142*