### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-09 - Missing ARIA labels in dynamic/interactive chat components
 **Learning:** Icon-only buttons in the core Chat component (`src/components/ui/chat.tsx`), particularly actions like "Thumbs up", "Thumbs down", and "Scroll to bottom", were missing `aria-label` attributes. Screen reader users would have no context for what these buttons do since they lack text nodes.
 **Action:** When implementing new features or components with interactive icon-only buttons (`size="icon"`), proactively add descriptive `aria-label` attributes.
+
+## 2026-03-26 - Missing ARIA labels for modal/panel close buttons
+**Learning:** Across multiple UI components, particularly those acting as modals, dialogs, or panels (like `reference-detail`, `search-result-export`, etc.), the icon-only `<Button variant="ghost"><X /></Button>` pattern for closing was consistently used without an `aria-label`. This makes the core 'close' action inaccessible to screen readers.
+**Action:** Always add an explicit `aria-label="Close"` to icon-only close buttons, especially those using `variant="ghost"` or `size="icon"`.

--- a/src/components/ui/ai-error-notification.tsx
+++ b/src/components/ui/ai-error-notification.tsx
@@ -2,7 +2,11 @@
 
 import React from "react";
 import { Button } from "@/components/ui/shadcn/button";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/shadcn/alert";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/shadcn/alert";
 import {
   AlertTriangle,
   Wifi,
@@ -97,7 +101,7 @@ export const AIErrorNotification: React.FC<AIErrorNotificationProps> = ({
   className,
 }) => {
   const [showDetails, setShowDetails] = React.useState(false);
-  
+
   const Icon = errorIcons[error.type] || AlertTriangle;
   const variant = errorVariants[error.type] || "default";
   const recoveryStrategy = AIErrorHandler.getRetryStrategy(error);
@@ -132,8 +136,10 @@ export const AIErrorNotification: React.FC<AIErrorNotificationProps> = ({
     }
   };
 
-  const shouldShowRetryButton = canRetry && recoveryStrategy.showRetryButton && onRetry;
-  const shouldShowGracefulDegradation = recoveryStrategy.gracefulDegradation && onGracefulDegradation;
+  const shouldShowRetryButton =
+    canRetry && recoveryStrategy.showRetryButton && onRetry;
+  const shouldShowGracefulDegradation =
+    recoveryStrategy.gracefulDegradation && onGracefulDegradation;
 
   return (
     <Alert variant={variant} className={cn("relative", className)}>
@@ -165,6 +171,7 @@ export const AIErrorNotification: React.FC<AIErrorNotificationProps> = ({
               </Button>
             )}
             <Button
+              aria-label="Close"
               variant="ghost"
               size="sm"
               onClick={onDismiss}
@@ -177,13 +184,13 @@ export const AIErrorNotification: React.FC<AIErrorNotificationProps> = ({
         <AlertDescription className="mt-2">
           <div className="space-y-2">
             <p>{userFriendlyMessage}</p>
-            
+
             {error.retryable && retryCount > 0 && (
               <p className="text-sm text-muted-foreground">
                 Retry attempt {retryCount} of {recoveryStrategy.retryAttempts}
               </p>
             )}
-            
+
             {error.code && (
               <Button
                 variant="ghost"
@@ -204,14 +211,22 @@ export const AIErrorNotification: React.FC<AIErrorNotificationProps> = ({
                 )}
               </Button>
             )}
-            
+
             {showDetails && (
               <div className="mt-2 p-2 bg-muted rounded text-xs font-mono space-y-1">
-                <div><strong>Error Code:</strong> {error.code}</div>
-                <div><strong>Type:</strong> {error.type}</div>
-                <div><strong>Retryable:</strong> {error.retryable ? 'Yes' : 'No'}</div>
+                <div>
+                  <strong>Error Code:</strong> {error.code}
+                </div>
+                <div>
+                  <strong>Type:</strong> {error.type}
+                </div>
+                <div>
+                  <strong>Retryable:</strong> {error.retryable ? "Yes" : "No"}
+                </div>
                 {error.originalError && (
-                  <div><strong>Details:</strong> {error.originalError.message}</div>
+                  <div>
+                    <strong>Details:</strong> {error.originalError.message}
+                  </div>
                 )}
               </div>
             )}

--- a/src/components/ui/attachment-menu.tsx
+++ b/src/components/ui/attachment-menu.tsx
@@ -1,20 +1,20 @@
-"use client"
+"use client";
 
-import React, { useState, useEffect } from "react"
-import { 
-  Lightbulb, 
-  FileText, 
-  AlertTriangle, 
-  BookOpen, 
+import React, { useState, useEffect } from "react";
+import {
+  Lightbulb,
+  FileText,
+  AlertTriangle,
+  BookOpen,
   Paperclip,
   Check,
   X,
   Loader2,
   Pencil,
-  Sparkles
-} from "lucide-react"
+  Sparkles,
+} from "lucide-react";
 
-import { Button } from "@/components/ui/shadcn/button"
+import { Button } from "@/components/ui/shadcn/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -22,7 +22,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/shadcn/dropdown-menu"
+} from "@/components/ui/shadcn/dropdown-menu";
 import {
   Dialog,
   DialogContent,
@@ -30,33 +30,33 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
-import { ScrollArea } from "@/components/ui/shadcn/scroll-area"
-import { Checkbox } from "@/components/ui/shadcn/checkbox"
-import { Badge } from "@/components/ui/shadcn/badge"
-import { Input } from "@/components/ui/shadcn/input"
-import { fetchIdeas, updateIdea, regenerateIdeaTitle } from "@/lib/idea-api"
-import { IdeaDefinition } from "@/lib/ai-types"
-import { ProofreadingConcern } from "@/lib/types/shared/common"
-import { Reference } from "@/lib/types/citation-types/reference-types"
-import { toast } from "sonner"
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/shadcn/scroll-area";
+import { Checkbox } from "@/components/ui/shadcn/checkbox";
+import { Badge } from "@/components/ui/shadcn/badge";
+import { Input } from "@/components/ui/shadcn/input";
+import { fetchIdeas, updateIdea, regenerateIdeaTitle } from "@/lib/idea-api";
+import { IdeaDefinition } from "@/lib/ai-types";
+import { ProofreadingConcern } from "@/lib/types/shared/common";
+import { Reference } from "@/lib/types/citation-types/reference-types";
+import { toast } from "sonner";
 
 /**
  * Represents an attached item from various sources (ideas, content, concerns, references)
  */
 export interface AttachedItem {
-  id: string
-  type: "idea" | "content" | "concern" | "reference"
-  title: string
-  description?: string
-  data: IdeaDefinition | string | ProofreadingConcern | Reference
+  id: string;
+  type: "idea" | "content" | "concern" | "reference";
+  title: string;
+  description?: string;
+  data: IdeaDefinition | string | ProofreadingConcern | Reference;
 }
 
 interface AttachmentMenuProps {
-  conversationId: string
-  attachedItems: AttachedItem[]
-  onAttachedItemsChange: (items: AttachedItem[]) => void
-  onFileUpload: () => Promise<void>
+  conversationId: string;
+  attachedItems: AttachedItem[];
+  onAttachedItemsChange: (items: AttachedItem[]) => void;
+  onFileUpload: () => Promise<void>;
 }
 
 /**
@@ -70,27 +70,29 @@ export function AttachmentMenu({
   onAttachedItemsChange,
   onFileUpload,
 }: AttachmentMenuProps) {
-  const [ideaDialogOpen, setIdeaDialogOpen] = useState(false)
-  const [contentDialogOpen, setContentDialogOpen] = useState(false)
-  const [concernDialogOpen, setConcernDialogOpen] = useState(false)
-  const [referenceDialogOpen, setReferenceDialogOpen] = useState(false)
+  const [ideaDialogOpen, setIdeaDialogOpen] = useState(false);
+  const [contentDialogOpen, setContentDialogOpen] = useState(false);
+  const [concernDialogOpen, setConcernDialogOpen] = useState(false);
+  const [referenceDialogOpen, setReferenceDialogOpen] = useState(false);
 
   const handleAttachItem = (item: AttachedItem) => {
     const exists = attachedItems.some(
-      (existing) => existing.id === item.id && existing.type === item.type
-    )
+      (existing) => existing.id === item.id && existing.type === item.type,
+    );
     if (!exists) {
-      onAttachedItemsChange([...attachedItems, item])
+      onAttachedItemsChange([...attachedItems, item]);
     }
-  }
+  };
 
   const handleRemoveItem = (itemId: string, itemType: string) => {
     onAttachedItemsChange(
-      attachedItems.filter((item) => !(item.id === itemId && item.type === itemType))
-    )
-  }
+      attachedItems.filter(
+        (item) => !(item.id === itemId && item.type === itemType),
+      ),
+    );
+  };
 
-  const getAttachedCount = () => attachedItems.length
+  const getAttachedCount = () => attachedItems.length;
 
   return (
     <>
@@ -105,8 +107,8 @@ export function AttachmentMenu({
           >
             <Paperclip className="h-4 w-4" />
             {getAttachedCount() > 0 && (
-              <Badge 
-                variant="default" 
+              <Badge
+                variant="default"
                 className="absolute -top-2 -right-2 h-5 w-5 p-0 flex items-center justify-center text-xs"
               >
                 {getAttachedCount()}
@@ -175,12 +177,14 @@ export function AttachmentMenu({
         open={referenceDialogOpen}
         onOpenChange={setReferenceDialogOpen}
         conversationId={conversationId}
-        selectedItems={attachedItems.filter((item) => item.type === "reference")}
+        selectedItems={attachedItems.filter(
+          (item) => item.type === "reference",
+        )}
         onSelect={handleAttachItem}
         onRemove={(id) => handleRemoveItem(id, "reference")}
       />
     </>
-  )
+  );
 }
 
 // ====================
@@ -188,12 +192,12 @@ export function AttachmentMenu({
 // ====================
 
 interface IdeaSelectorDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  conversationId: string
-  selectedItems: AttachedItem[]
-  onSelect: (item: AttachedItem) => void
-  onRemove: (id: string) => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  conversationId: string;
+  selectedItems: AttachedItem[];
+  onSelect: (item: AttachedItem) => void;
+  onRemove: (id: string) => void;
 }
 
 function IdeaSelectorDialog({
@@ -204,41 +208,43 @@ function IdeaSelectorDialog({
   onSelect,
   onRemove,
 }: IdeaSelectorDialogProps) {
-  const [ideas, setIdeas] = useState<IdeaDefinition[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [editingId, setEditingId] = useState<string | number | null>(null)
-  const [editingTitle, setEditingTitle] = useState("")
-  const [isUpdating, setIsUpdating] = useState(false)
-  const [regeneratingId, setRegeneratingId] = useState<string | number | null>(null)
+  const [ideas, setIdeas] = useState<IdeaDefinition[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | number | null>(null);
+  const [editingTitle, setEditingTitle] = useState("");
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [regeneratingId, setRegeneratingId] = useState<string | number | null>(
+    null,
+  );
 
   useEffect(() => {
     if (open && conversationId) {
-      loadIdeas()
+      loadIdeas();
     }
-  }, [open, conversationId])
+  }, [open, conversationId]);
 
   const loadIdeas = async () => {
     try {
-      setLoading(true)
-      setError(null)
-      const fetchedIdeas = await fetchIdeas(conversationId)
-      setIdeas(fetchedIdeas)
+      setLoading(true);
+      setError(null);
+      const fetchedIdeas = await fetchIdeas(conversationId);
+      setIdeas(fetchedIdeas);
     } catch (err) {
-      setError("Failed to load ideas")
-      console.error(err)
+      setError("Failed to load ideas");
+      console.error(err);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
-  const isSelected = (id: string | number) => 
-    selectedItems.some((item) => item.id === String(id))
+  const isSelected = (id: string | number) =>
+    selectedItems.some((item) => item.id === String(id));
 
   const handleToggle = (idea: IdeaDefinition) => {
-    const ideaId = String(idea.id)
+    const ideaId = String(idea.id);
     if (isSelected(idea.id)) {
-      onRemove(ideaId)
+      onRemove(ideaId);
     } else {
       onSelect({
         id: ideaId,
@@ -246,67 +252,76 @@ function IdeaSelectorDialog({
         title: idea.title,
         description: idea.description,
         data: idea,
-      })
+      });
     }
-  }
+  };
 
   const handleStartEdit = (idea: IdeaDefinition, e: React.MouseEvent) => {
-    e.stopPropagation()
-    setEditingId(idea.id)
-    setEditingTitle(idea.title)
-  }
+    e.stopPropagation();
+    setEditingId(idea.id);
+    setEditingTitle(idea.title);
+  };
 
   const handleCancelEdit = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    setEditingId(null)
-    setEditingTitle("")
-  }
+    e.stopPropagation();
+    setEditingId(null);
+    setEditingTitle("");
+  };
 
   const handleSaveEdit = async (idea: IdeaDefinition, e: React.MouseEvent) => {
-    e.stopPropagation()
+    e.stopPropagation();
     if (!editingTitle.trim()) {
-      toast.error("Title cannot be empty")
-      return
+      toast.error("Title cannot be empty");
+      return;
     }
 
     try {
-      setIsUpdating(true)
-      await updateIdea(Number(idea.id), { title: editingTitle.trim() })
-      setIdeas(prev => prev.map(i => 
-        i.id === idea.id ? { ...i, title: editingTitle.trim() } : i
-      ))
-      setEditingId(null)
-      setEditingTitle("")
-      toast.success("Title updated successfully")
+      setIsUpdating(true);
+      await updateIdea(Number(idea.id), { title: editingTitle.trim() });
+      setIdeas((prev) =>
+        prev.map((i) =>
+          i.id === idea.id ? { ...i, title: editingTitle.trim() } : i,
+        ),
+      );
+      setEditingId(null);
+      setEditingTitle("");
+      toast.success("Title updated successfully");
     } catch (err) {
-      console.error("Failed to update title:", err)
-      toast.error("Failed to update title")
+      console.error("Failed to update title:", err);
+      toast.error("Failed to update title");
     } finally {
-      setIsUpdating(false)
+      setIsUpdating(false);
     }
-  }
+  };
 
-  const handleRegenerateTitle = async (idea: IdeaDefinition, e: React.MouseEvent) => {
-    e.stopPropagation()
+  const handleRegenerateTitle = async (
+    idea: IdeaDefinition,
+    e: React.MouseEvent,
+  ) => {
+    e.stopPropagation();
     if (!idea.description) {
-      toast.error("Cannot regenerate title without a description")
-      return
+      toast.error("Cannot regenerate title without a description");
+      return;
     }
 
     try {
-      setRegeneratingId(idea.id)
-      const result = await regenerateIdeaTitle(Number(idea.id), idea.description, conversationId)
-      setIdeas(prev => prev.map(i => 
-        i.id === idea.id ? { ...i, title: result.title } : i
-      ))
-      toast.success("Title regenerated successfully")
+      setRegeneratingId(idea.id);
+      const result = await regenerateIdeaTitle(
+        Number(idea.id),
+        idea.description,
+        conversationId,
+      );
+      setIdeas((prev) =>
+        prev.map((i) => (i.id === idea.id ? { ...i, title: result.title } : i)),
+      );
+      toast.success("Title regenerated successfully");
     } catch (err) {
-      console.error("Failed to regenerate title:", err)
-      toast.error("Failed to regenerate title")
+      console.error("Failed to regenerate title:", err);
+      toast.error("Failed to regenerate title");
     } finally {
-      setRegeneratingId(null)
+      setRegeneratingId(null);
     }
-  }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -350,7 +365,10 @@ function IdeaSelectorDialog({
                   />
                   <div className="flex-1 min-w-0">
                     {editingId === idea.id ? (
-                      <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                      <div
+                        className="flex items-center gap-2"
+                        onClick={(e) => e.stopPropagation()}
+                      >
                         <Input
                           value={editingTitle}
                           onChange={(e) => setEditingTitle(e.target.value)}
@@ -358,10 +376,15 @@ function IdeaSelectorDialog({
                           autoFocus
                           disabled={isUpdating}
                           onKeyDown={(e) => {
-                            if (e.key === 'Enter') {
-                              handleSaveEdit(idea, e as unknown as React.MouseEvent)
-                            } else if (e.key === 'Escape') {
-                              handleCancelEdit(e as unknown as React.MouseEvent)
+                            if (e.key === "Enter") {
+                              handleSaveEdit(
+                                idea,
+                                e as unknown as React.MouseEvent,
+                              );
+                            } else if (e.key === "Escape") {
+                              handleCancelEdit(
+                                e as unknown as React.MouseEvent,
+                              );
                             }
                           }}
                         />
@@ -379,6 +402,7 @@ function IdeaSelectorDialog({
                           )}
                         </Button>
                         <Button
+                          aria-label="Close"
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7"
@@ -390,7 +414,7 @@ function IdeaSelectorDialog({
                       </div>
                     ) : (
                       <div className="flex items-center gap-2">
-                        <span 
+                        <span
                           className="font-medium text-sm truncate flex-1 cursor-pointer"
                           onClick={() => handleToggle(idea)}
                         >
@@ -413,7 +437,9 @@ function IdeaSelectorDialog({
                           size="icon"
                           className="h-6 w-6 shrink-0"
                           onClick={(e) => handleRegenerateTitle(idea, e)}
-                          disabled={regeneratingId === idea.id || !idea.description}
+                          disabled={
+                            regeneratingId === idea.id || !idea.description
+                          }
                           title="Regenerate title with AI"
                         >
                           {regeneratingId === idea.id ? (
@@ -425,7 +451,7 @@ function IdeaSelectorDialog({
                       </div>
                     )}
                     {idea.description && (
-                      <p 
+                      <p
                         className="text-xs text-muted-foreground mt-1 line-clamp-2 cursor-pointer"
                         onClick={() => handleToggle(idea)}
                       >
@@ -446,7 +472,7 @@ function IdeaSelectorDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 // =======================
@@ -454,12 +480,12 @@ function IdeaSelectorDialog({
 // =======================
 
 interface ContentSelectorDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  conversationId: string
-  selectedItems: AttachedItem[]
-  onSelect: (item: AttachedItem) => void
-  onRemove: (id: string) => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  conversationId: string;
+  selectedItems: AttachedItem[];
+  onSelect: (item: AttachedItem) => void;
+  onRemove: (id: string) => void;
 }
 
 function ContentSelectorDialog({
@@ -470,54 +496,59 @@ function ContentSelectorDialog({
   onSelect,
   onRemove,
 }: ContentSelectorDialogProps) {
-  const [content, setContent] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open && conversationId) {
-      loadContent()
+      loadContent();
     }
-  }, [open, conversationId])
+  }, [open, conversationId]);
 
   const loadContent = async () => {
     try {
-      setLoading(true)
-      setError(null)
-      const response = await fetch(`/api/builder-content/${encodeURIComponent(conversationId)}`)
+      setLoading(true);
+      setError(null);
+      const response = await fetch(
+        `/api/builder-content/${encodeURIComponent(conversationId)}`,
+      );
       if (response.ok) {
-        const data = await response.json()
+        const data = await response.json();
         if (data.success && data.content) {
-          setContent(data.content)
+          setContent(data.content);
         } else {
-          setContent(null)
+          setContent(null);
         }
       } else {
-        setContent(null)
+        setContent(null);
       }
     } catch (err) {
-      setError("Failed to load content")
-      console.error(err)
+      setError("Failed to load content");
+      console.error(err);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
-  const isSelected = selectedItems.some((item) => item.id === "builder-content")
+  const isSelected = selectedItems.some(
+    (item) => item.id === "builder-content",
+  );
 
   const handleToggle = () => {
     if (isSelected) {
-      onRemove("builder-content")
+      onRemove("builder-content");
     } else if (content) {
       onSelect({
         id: "builder-content",
         type: "content",
         title: "Builder Content",
-        description: content.substring(0, 100) + (content.length > 100 ? "..." : ""),
+        description:
+          content.substring(0, 100) + (content.length > 100 ? "..." : ""),
         data: content,
-      })
+      });
     }
-  }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -575,7 +606,7 @@ function ContentSelectorDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 // =======================
@@ -583,12 +614,12 @@ function ContentSelectorDialog({
 // =======================
 
 interface ConcernSelectorDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  conversationId: string
-  selectedItems: AttachedItem[]
-  onSelect: (item: AttachedItem) => void
-  onRemove: (id: string) => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  conversationId: string;
+  selectedItems: AttachedItem[];
+  onSelect: (item: AttachedItem) => void;
+  onRemove: (id: string) => void;
 }
 
 function ConcernSelectorDialog({
@@ -599,73 +630,77 @@ function ConcernSelectorDialog({
   onSelect,
   onRemove,
 }: ConcernSelectorDialogProps) {
-  const [concerns, setConcerns] = useState<ProofreadingConcern[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [concerns, setConcerns] = useState<ProofreadingConcern[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open && conversationId) {
-      loadConcerns()
+      loadConcerns();
     }
-  }, [open, conversationId])
+  }, [open, conversationId]);
 
   const loadConcerns = async () => {
     try {
-      setLoading(true)
-      setError(null)
-      const response = await fetch(`/api/proofreader/concerns/${encodeURIComponent(conversationId)}`)
+      setLoading(true);
+      setError(null);
+      const response = await fetch(
+        `/api/proofreader/concerns/${encodeURIComponent(conversationId)}`,
+      );
       if (response.ok) {
-        const data = await response.json()
+        const data = await response.json();
         if (data.success && Array.isArray(data.concerns)) {
-          setConcerns(data.concerns)
+          setConcerns(data.concerns);
         } else {
-          setConcerns([])
+          setConcerns([]);
         }
       } else {
-        setConcerns([])
+        setConcerns([]);
       }
     } catch (err) {
-      setError("Failed to load concerns")
-      console.error(err)
+      setError("Failed to load concerns");
+      console.error(err);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
-  const isSelected = (id: string) => 
-    selectedItems.some((item) => item.id === id)
+  const isSelected = (id: string) =>
+    selectedItems.some((item) => item.id === id);
 
   const handleToggle = (concern: ProofreadingConcern) => {
     if (isSelected(concern.id)) {
-      onRemove(concern.id)
+      onRemove(concern.id);
     } else {
       // Use title or text for display, preferring title for AI-generated concerns
-      const displayText = concern.title || concern.text || concern.description || ''
-      const displayTitle = displayText.length > 50 
-        ? `${concern.category}: ${displayText.substring(0, 50)}...`
-        : `${concern.category}: ${displayText}`
+      const displayText =
+        concern.title || concern.text || concern.description || "";
+      const displayTitle =
+        displayText.length > 50
+          ? `${concern.category}: ${displayText.substring(0, 50)}...`
+          : `${concern.category}: ${displayText}`;
       onSelect({
         id: concern.id,
         type: "concern",
         title: displayTitle,
         description: concern.explanation || concern.description,
         data: concern,
-      })
+      });
     }
-  }
+  };
 
   const getSeverityColor = (severity: string) => {
     switch (severity) {
       case "critical":
-        return "text-red-500"
+        return "text-red-500";
       case "high":
-        return "text-orange-500"
+        return "text-orange-500";
       case "medium":
-        return "text-yellow-500"
+        return "text-yellow-500";
       default:
-        return "text-blue-500"
+        return "text-blue-500";
     }
-  }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -694,10 +729,13 @@ function ConcernSelectorDialog({
           ) : (
             <div className="space-y-2">
               {concerns.map((concern) => {
-                const isAIGenerated = (concern as any).aiGenerated === true || 
-                  (typeof concern.explanation === 'string' && concern.explanation.startsWith('(AI-generated)'))
-                const displayText = concern.title || concern.text || concern.description || ''
-                
+                const isAIGenerated =
+                  (concern as any).aiGenerated === true ||
+                  (typeof concern.explanation === "string" &&
+                    concern.explanation.startsWith("(AI-generated)"));
+                const displayText =
+                  concern.title || concern.text || concern.description || "";
+
                 return (
                   <div
                     key={concern.id}
@@ -717,8 +755,8 @@ function ConcernSelectorDialog({
                         <Badge variant="outline" className="text-xs">
                           {concern.category}
                         </Badge>
-                        <Badge 
-                          variant="outline" 
+                        <Badge
+                          variant="outline"
                           className={`text-xs ${getSeverityColor(concern.severity)}`}
                         >
                           {concern.severity}
@@ -731,14 +769,15 @@ function ConcernSelectorDialog({
                         )}
                       </div>
                       <p className="text-sm mt-1 line-clamp-2">{displayText}</p>
-                      {concern.description && concern.description !== displayText && (
-                        <p className="text-xs text-muted-foreground mt-1 line-clamp-1">
-                          {concern.description}
-                        </p>
-                      )}
+                      {concern.description &&
+                        concern.description !== displayText && (
+                          <p className="text-xs text-muted-foreground mt-1 line-clamp-1">
+                            {concern.description}
+                          </p>
+                        )}
                     </div>
                   </div>
-                )
+                );
               })}
             </div>
           )}
@@ -751,7 +790,7 @@ function ConcernSelectorDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 // =========================
@@ -759,12 +798,12 @@ function ConcernSelectorDialog({
 // =========================
 
 interface ReferenceSelectorDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  conversationId: string
-  selectedItems: AttachedItem[]
-  onSelect: (item: AttachedItem) => void
-  onRemove: (id: string) => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  conversationId: string;
+  selectedItems: AttachedItem[];
+  onSelect: (item: AttachedItem) => void;
+  onRemove: (id: string) => void;
 }
 
 function ReferenceSelectorDialog({
@@ -775,61 +814,67 @@ function ReferenceSelectorDialog({
   onSelect,
   onRemove,
 }: ReferenceSelectorDialogProps) {
-  const [references, setReferences] = useState<Reference[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [references, setReferences] = useState<Reference[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open && conversationId) {
-      loadReferences()
+      loadReferences();
     }
-  }, [open, conversationId])
+  }, [open, conversationId]);
 
   const loadReferences = async () => {
     try {
-      setLoading(true)
-      setError(null)
+      setLoading(true);
+      setError(null);
       // Use correct API path: /api/referencer/references/:conversationId
-      const response = await fetch(`/api/referencer/references/${encodeURIComponent(conversationId)}`)
+      const response = await fetch(
+        `/api/referencer/references/${encodeURIComponent(conversationId)}`,
+      );
       if (response.ok) {
-        const data = await response.json()
+        const data = await response.json();
         if (data.success && Array.isArray(data.references)) {
-          setReferences(data.references)
+          setReferences(data.references);
         } else if (Array.isArray(data)) {
-          setReferences(data)
+          setReferences(data);
         } else {
-          setReferences([])
+          setReferences([]);
         }
       } else {
-        setReferences([])
+        setReferences([]);
       }
     } catch (err) {
-      setError("Failed to load references")
-      console.error(err)
+      setError("Failed to load references");
+      console.error(err);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
-  const isSelected = (id: string) => 
-    selectedItems.some((item) => item.id === id)
+  const isSelected = (id: string) =>
+    selectedItems.some((item) => item.id === id);
 
   const handleToggle = (reference: Reference) => {
     if (isSelected(reference.id)) {
-      onRemove(reference.id)
+      onRemove(reference.id);
     } else {
-      const authors = Array.isArray(reference.authors) 
-        ? reference.authors.map(a => typeof a === 'string' ? a : `${a.firstName} ${a.lastName}`).join(", ")
-        : ""
+      const authors = Array.isArray(reference.authors)
+        ? reference.authors
+            .map((a) =>
+              typeof a === "string" ? a : `${a.firstName} ${a.lastName}`,
+            )
+            .join(", ")
+        : "";
       onSelect({
         id: reference.id,
         type: "reference",
         title: reference.title,
         description: `${authors}${reference.publication_date ? ` (${new Date(reference.publication_date).getFullYear()})` : ""}`,
         data: reference,
-      })
+      });
     }
-  }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -858,9 +903,15 @@ function ReferenceSelectorDialog({
           ) : (
             <div className="space-y-2">
               {references.map((reference) => {
-                const authors = Array.isArray(reference.authors) 
-                  ? reference.authors.map(a => typeof a === 'string' ? a : `${a.firstName} ${a.lastName}`).join(", ")
-                  : ""
+                const authors = Array.isArray(reference.authors)
+                  ? reference.authors
+                      .map((a) =>
+                        typeof a === "string"
+                          ? a
+                          : `${a.firstName} ${a.lastName}`,
+                      )
+                      .join(", ")
+                  : "";
                 return (
                   <div
                     key={reference.id}
@@ -896,7 +947,7 @@ function ReferenceSelectorDialog({
                       )}
                     </div>
                   </div>
-                )
+                );
               })}
             </div>
           )}
@@ -909,5 +960,5 @@ function ReferenceSelectorDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/src/components/ui/citation-insertion.tsx
+++ b/src/components/ui/citation-insertion.tsx
@@ -1,29 +1,29 @@
-"use client"
+"use client";
 
-import React, { useState } from "react"
-import { Button } from "./shadcn/button"
-import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card"
-import { Badge } from "./shadcn/badge"
-import { Separator } from "./shadcn/separator"
-import { CitationStyle, Reference } from "../../lib/ai-types"
-import { X, Quote, FileText } from "lucide-react"
+import React, { useState } from "react";
+import { Button } from "./shadcn/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card";
+import { Badge } from "./shadcn/badge";
+import { Separator } from "./shadcn/separator";
+import { CitationStyle, Reference } from "../../lib/ai-types";
+import { X, Quote, FileText } from "lucide-react";
 
 interface CitationInsertionProps {
-  selectedText?: string
-  onCitationInsert: (citation: string) => Promise<boolean>
-  onBibliographyInsert: (bibliography: string) => Promise<boolean>
-  currentCitationStyle: CitationStyle
-  availableReferences?: Reference[]
-  onClose: () => void
-  className?: string
+  selectedText?: string;
+  onCitationInsert: (citation: string) => Promise<boolean>;
+  onBibliographyInsert: (bibliography: string) => Promise<boolean>;
+  currentCitationStyle: CitationStyle;
+  availableReferences?: Reference[];
+  onClose: () => void;
+  className?: string;
 }
 
 interface InsertionState {
-  selectedReferences: Reference[]
-  inlineCitation: string
-  bibliographyEntry: string
-  isProcessing: boolean
-  error: string | null
+  selectedReferences: Reference[];
+  inlineCitation: string;
+  bibliographyEntry: string;
+  isProcessing: boolean;
+  error: string | null;
 }
 
 /**
@@ -80,161 +80,190 @@ export const CitationInsertion: React.FC<CitationInsertionProps> = ({
   currentCitationStyle,
   availableReferences = [],
   onClose,
-  className = ''
+  className = "",
 }) => {
   const [state, setState] = useState<InsertionState>({
     selectedReferences: [],
-    inlineCitation: '',
-    bibliographyEntry: '',
+    inlineCitation: "",
+    bibliographyEntry: "",
     isProcessing: false,
-    error: null
-  })
+    error: null,
+  });
 
-  const [showPreview, setShowPreview] = useState(false)
+  const [showPreview, setShowPreview] = useState(false);
 
   // Filter references based on selected text if available
   const relevantReferences = React.useMemo(() => {
     if (!selectedText || availableReferences.length === 0) {
-      return availableReferences
+      return availableReferences;
     }
 
-    const searchText = selectedText.toLowerCase()
-    return availableReferences.filter(ref =>
-      ref.title.toLowerCase().includes(searchText) ||
-      ref.authors.some(author =>
-        `${author.firstName} ${author.lastName}`.toLowerCase().includes(searchText)
-      ) ||
-      (ref.journal && ref.journal.toLowerCase().includes(searchText))
-    )
-  }, [availableReferences, selectedText])
+    const searchText = selectedText.toLowerCase();
+    return availableReferences.filter(
+      (ref) =>
+        ref.title.toLowerCase().includes(searchText) ||
+        ref.authors.some((author) =>
+          `${author.firstName} ${author.lastName}`
+            .toLowerCase()
+            .includes(searchText),
+        ) ||
+        (ref.journal && ref.journal.toLowerCase().includes(searchText)),
+    );
+  }, [availableReferences, selectedText]);
 
   const handleReferenceSelect = (reference: Reference) => {
-    setState(prev => ({
+    setState((prev) => ({
       ...prev,
       selectedReferences: prev.selectedReferences.includes(reference)
-        ? prev.selectedReferences.filter(r => r.id !== reference.id)
-        : [...prev.selectedReferences, reference]
-    }))
-  }
+        ? prev.selectedReferences.filter((r) => r.id !== reference.id)
+        : [...prev.selectedReferences, reference],
+    }));
+  };
 
   const handleRemoveReference = (referenceId: string) => {
-    setState(prev => ({
+    setState((prev) => ({
       ...prev,
-      selectedReferences: prev.selectedReferences.filter(r => r.id !== referenceId)
-    }))
-  }
+      selectedReferences: prev.selectedReferences.filter(
+        (r) => r.id !== referenceId,
+      ),
+    }));
+  };
 
   const handleCitationPreview = async () => {
-    if (state.selectedReferences.length === 0) return
+    if (state.selectedReferences.length === 0) return;
 
-    setState(prev => ({ ...prev, isProcessing: true, error: null }))
+    setState((prev) => ({ ...prev, isProcessing: true, error: null }));
 
     try {
       // Format citation using the citation formatter
-      const citation = await formatCitation(state.selectedReferences, currentCitationStyle)
-      const bibliography = await formatBibliography(state.selectedReferences, currentCitationStyle)
+      const citation = await formatCitation(
+        state.selectedReferences,
+        currentCitationStyle,
+      );
+      const bibliography = await formatBibliography(
+        state.selectedReferences,
+        currentCitationStyle,
+      );
 
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
         inlineCitation: citation,
         bibliographyEntry: bibliography,
-        isProcessing: false
-      }))
+        isProcessing: false,
+      }));
 
-      setShowPreview(true)
+      setShowPreview(true);
     } catch (error) {
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
-        error: error instanceof Error ? error.message : 'Failed to format citation',
-        isProcessing: false
-      }))
+        error:
+          error instanceof Error ? error.message : "Failed to format citation",
+        isProcessing: false,
+      }));
     }
-  }
+  };
 
   const handleInsertCitation = async () => {
-    if (!state.inlineCitation) return
+    if (!state.inlineCitation) return;
 
-    setState(prev => ({ ...prev, isProcessing: true }))
+    setState((prev) => ({ ...prev, isProcessing: true }));
 
     try {
-      const success = await onCitationInsert(state.inlineCitation)
+      const success = await onCitationInsert(state.inlineCitation);
       if (success) {
-        onClose()
+        onClose();
       }
     } catch (error) {
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
-        error: error instanceof Error ? error.message : 'Failed to insert citation',
-        isProcessing: false
-      }))
+        error:
+          error instanceof Error ? error.message : "Failed to insert citation",
+        isProcessing: false,
+      }));
     }
-  }
+  };
 
   const handleInsertBibliography = async () => {
-    if (!state.bibliographyEntry) return
+    if (!state.bibliographyEntry) return;
 
-    setState(prev => ({ ...prev, isProcessing: true }))
+    setState((prev) => ({ ...prev, isProcessing: true }));
 
     try {
-      const success = await onBibliographyInsert(state.bibliographyEntry)
+      const success = await onBibliographyInsert(state.bibliographyEntry);
       if (success) {
-        onClose()
+        onClose();
       }
     } catch (error) {
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
-        error: error instanceof Error ? error.message : 'Failed to insert bibliography',
-        isProcessing: false
-      }))
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to insert bibliography",
+        isProcessing: false,
+      }));
     }
-  }
+  };
 
   // Mock citation formatting (would be replaced with actual citation engine)
-  const formatCitation = async (references: Reference[], style: CitationStyle): Promise<string> => {
-    if (references.length === 0) return ''
+  const formatCitation = async (
+    references: Reference[],
+    style: CitationStyle,
+  ): Promise<string> => {
+    if (references.length === 0) return "";
 
-    const firstRef = references[0]
-    const firstAuthor = firstRef.authors[0]
-    const year = firstRef.publicationDate ? new Date(firstRef.publicationDate).getFullYear() : 'n.d.'
-
-    switch (style) {
-      case CitationStyle.APA:
-        return `(${firstAuthor?.lastName || 'Unknown'}, ${year})`
-      case CitationStyle.MLA:
-        return `(${firstAuthor?.lastName || 'Unknown'} ${year})`
-      case CitationStyle.CHICAGO:
-        return `(${firstAuthor?.lastName || 'Unknown'}, ${year})`
-      default:
-        return `(${firstAuthor?.lastName || 'Unknown'}, ${year})`
-    }
-  }
-
-  const formatBibliography = async (references: Reference[], style: CitationStyle): Promise<string> => {
-    if (references.length === 0) return ''
-
-    const firstRef = references[0]
-    const authors = firstRef.authors.map(author =>
-      `${author.lastName}, ${author.firstName}${author.middleName ? ` ${author.middleName}` : ''}`
-    ).join(', ')
-
-    const year = firstRef.publicationDate ? new Date(firstRef.publicationDate).getFullYear() : 'n.d.'
-    const title = firstRef.title
-    const journal = firstRef.journal || ''
-    const volume = firstRef.volume || ''
-    const issue = firstRef.issue || ''
-    const pages = firstRef.pages || ''
+    const firstRef = references[0];
+    const firstAuthor = firstRef.authors[0];
+    const year = firstRef.publicationDate
+      ? new Date(firstRef.publicationDate).getFullYear()
+      : "n.d.";
 
     switch (style) {
       case CitationStyle.APA:
-        return `${authors} (${year}). ${title}.${journal ? ` ${journal}` : ''}${volume ? `, ${volume}` : ''}${issue ? `(${issue})` : ''}${pages ? `, ${pages}` : ''}.`
+        return `(${firstAuthor?.lastName || "Unknown"}, ${year})`;
       case CitationStyle.MLA:
-        return `${authors}. "${title}." ${journal}${volume ? ` ${volume}` : ''}${issue ? `.${issue}` : ''}${pages ? ` (${pages})` : ''} ${year}.`
+        return `(${firstAuthor?.lastName || "Unknown"} ${year})`;
       case CitationStyle.CHICAGO:
-        return `${authors}. "${title}." ${journal} ${volume}${issue ? `, no. ${issue}` : ''} (${year}): ${pages}.`
+        return `(${firstAuthor?.lastName || "Unknown"}, ${year})`;
       default:
-        return `${authors} (${year}). ${title}.`
+        return `(${firstAuthor?.lastName || "Unknown"}, ${year})`;
     }
-  }
+  };
+
+  const formatBibliography = async (
+    references: Reference[],
+    style: CitationStyle,
+  ): Promise<string> => {
+    if (references.length === 0) return "";
+
+    const firstRef = references[0];
+    const authors = firstRef.authors
+      .map(
+        (author) =>
+          `${author.lastName}, ${author.firstName}${author.middleName ? ` ${author.middleName}` : ""}`,
+      )
+      .join(", ");
+
+    const year = firstRef.publicationDate
+      ? new Date(firstRef.publicationDate).getFullYear()
+      : "n.d.";
+    const title = firstRef.title;
+    const journal = firstRef.journal || "";
+    const volume = firstRef.volume || "";
+    const issue = firstRef.issue || "";
+    const pages = firstRef.pages || "";
+
+    switch (style) {
+      case CitationStyle.APA:
+        return `${authors} (${year}). ${title}.${journal ? ` ${journal}` : ""}${volume ? `, ${volume}` : ""}${issue ? `(${issue})` : ""}${pages ? `, ${pages}` : ""}.`;
+      case CitationStyle.MLA:
+        return `${authors}. "${title}." ${journal}${volume ? ` ${volume}` : ""}${issue ? `.${issue}` : ""}${pages ? ` (${pages})` : ""} ${year}.`;
+      case CitationStyle.CHICAGO:
+        return `${authors}. "${title}." ${journal} ${volume}${issue ? `, no. ${issue}` : ""} (${year}): ${pages}.`;
+      default:
+        return `${authors} (${year}). ${title}.`;
+    }
+  };
 
   return (
     <div className={`space-y-4 ${className}`}>
@@ -245,11 +274,15 @@ export const CitationInsertion: React.FC<CitationInsertionProps> = ({
           <h3 className="text-lg font-semibold">Insert Citation</h3>
           {selectedText && (
             <Badge variant="secondary" className="text-xs">
-              Selected: "{selectedText.length > 20 ? selectedText.substring(0, 20) + '...' : selectedText}"
+              Selected: "
+              {selectedText.length > 20
+                ? selectedText.substring(0, 20) + "..."
+                : selectedText}
+              "
             </Badge>
           )}
         </div>
-        <Button variant="ghost" size="sm" onClick={onClose}>
+        <Button aria-label="Close" variant="ghost" size="sm" onClick={onClose}>
           <X className="h-4 w-4" />
         </Button>
       </div>
@@ -276,20 +309,22 @@ export const CitationInsertion: React.FC<CitationInsertionProps> = ({
                 key={reference.id}
                 className={`p-3 border rounded-lg cursor-pointer transition-colors ${
                   state.selectedReferences.includes(reference)
-                    ? 'border-primary bg-primary/5'
-                    : 'border-border hover:bg-muted/50'
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:bg-muted/50"
                 }`}
                 onClick={() => handleReferenceSelect(reference)}
               >
                 <div className="flex items-center justify-between">
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">{reference.title}</p>
+                    <p className="text-sm font-medium truncate">
+                      {reference.title}
+                    </p>
                     <p className="text-xs text-muted-foreground">
-                      {reference.authors[0] ?
-                        `${reference.authors[0].lastName}, ${reference.authors[0].firstName}` :
-                        'Unknown author'
-                      }
-                      {reference.publicationDate && ` (${new Date(reference.publicationDate).getFullYear()})`}
+                      {reference.authors[0]
+                        ? `${reference.authors[0].lastName}, ${reference.authors[0].firstName}`
+                        : "Unknown author"}
+                      {reference.publicationDate &&
+                        ` (${new Date(reference.publicationDate).getFullYear()})`}
                     </p>
                   </div>
                   {state.selectedReferences.includes(reference) && (
@@ -312,7 +347,10 @@ export const CitationInsertion: React.FC<CitationInsertionProps> = ({
             <h4 className="text-sm font-medium">Selected References</h4>
             <div className="space-y-1">
               {state.selectedReferences.map((reference) => (
-                <div key={reference.id} className="flex items-center justify-between p-2 bg-muted/50 rounded">
+                <div
+                  key={reference.id}
+                  className="flex items-center justify-between p-2 bg-muted/50 rounded"
+                >
                   <span className="text-xs truncate">{reference.title}</span>
                   <Button
                     variant="ghost"
@@ -342,7 +380,7 @@ export const CitationInsertion: React.FC<CitationInsertionProps> = ({
           disabled={state.selectedReferences.length === 0 || state.isProcessing}
           className="flex-1"
         >
-          {state.isProcessing ? 'Processing...' : 'Preview Citation'}
+          {state.isProcessing ? "Processing..." : "Preview Citation"}
         </Button>
       </div>
 
@@ -413,5 +451,5 @@ export const CitationInsertion: React.FC<CitationInsertionProps> = ({
         </Card>
       )}
     </div>
-  )
-}
+  );
+};

--- a/src/components/ui/reference-detail.tsx
+++ b/src/components/ui/reference-detail.tsx
@@ -1,20 +1,26 @@
-"use client"
+"use client";
 
-import React, { useState } from "react"
-import { toast } from "sonner"
-import { Button } from "@/components/ui/shadcn/button"
-import { Input } from "@/components/ui/shadcn/input"
-import { Label } from "@/components/ui/shadcn/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/shadcn/select"
-import { Badge } from "@/components/ui/shadcn/badge"
-import { Separator } from "@/components/ui/shadcn/separator"
-import { ScrollArea } from "@/components/ui/shadcn/scroll-area"
-import { 
-  Edit3, 
-  X, 
-  Trash2, 
-  Plus, 
-  ExternalLink, 
+import React, { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/shadcn/button";
+import { Input } from "@/components/ui/shadcn/input";
+import { Label } from "@/components/ui/shadcn/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/shadcn/select";
+import { Badge } from "@/components/ui/shadcn/badge";
+import { Separator } from "@/components/ui/shadcn/separator";
+import { ScrollArea } from "@/components/ui/shadcn/scroll-area";
+import {
+  Edit3,
+  X,
+  Trash2,
+  Plus,
+  ExternalLink,
   Copy,
   Calendar,
   Users,
@@ -25,33 +31,33 @@ import {
   Briefcase,
   Shield,
   MoreHorizontal,
-  Tag
-} from "lucide-react"
-import { 
-  Reference, 
-  ReferenceType, 
-  Author, 
-  CitationStyle
-} from "@/lib/ai-types"
+  Tag,
+} from "lucide-react";
+import {
+  Reference,
+  ReferenceType,
+  Author,
+  CitationStyle,
+} from "@/lib/ai-types";
 
 /**
  * Props for the ReferenceDetail component
  */
 interface ReferenceDetailProps {
   /** The reference to display */
-  reference: Reference
+  reference: Reference;
   /** Callback function called when the edit button is clicked */
-  onEdit: (reference: Reference) => void
+  onEdit: (reference: Reference) => void;
   /** Callback function called when the delete button is clicked */
-  onDelete: (referenceId: string) => void
+  onDelete: (referenceId: string) => void;
   /** Callback function called when a tag is added */
-  onTagAdd: (referenceId: string, tag: string) => void
+  onTagAdd: (referenceId: string, tag: string) => void;
   /** Callback function called when a tag is removed */
-  onTagRemove: (referenceId: string, tag: string) => void
+  onTagRemove: (referenceId: string, tag: string) => void;
   /** Callback function called when the close button is clicked */
-  onClose: () => void
+  onClose: () => void;
   /** Whether the component is in a loading state */
-  isLoading?: boolean
+  isLoading?: boolean;
 }
 
 /**
@@ -59,34 +65,37 @@ interface ReferenceDetailProps {
  */
 interface ReferenceDetailState {
   /** Whether the user is currently editing tags */
-  editingTags: boolean
+  editingTags: boolean;
   /** The new tag being added */
-  newTag: string
+  newTag: string;
   /** The currently selected citation style for preview */
-  selectedCitationStyle: CitationStyle
+  selectedCitationStyle: CitationStyle;
   /** Whether to show the delete confirmation dialog */
-  showDeleteConfirmation: boolean
+  showDeleteConfirmation: boolean;
 }
 
 /**
  * Mapping of reference types to display labels
  */
 const REFERENCE_TYPE_LABELS: Record<ReferenceType, string> = {
-  [ReferenceType.JOURNAL_ARTICLE]: 'Journal Article',
-  [ReferenceType.BOOK]: 'Book',
-  [ReferenceType.BOOK_CHAPTER]: 'Book Chapter',
-  [ReferenceType.CONFERENCE_PAPER]: 'Conference Paper',
-  [ReferenceType.THESIS]: 'Thesis',
-  [ReferenceType.WEBSITE]: 'Website',
-  [ReferenceType.REPORT]: 'Report',
-  [ReferenceType.PATENT]: 'Patent',
-  [ReferenceType.OTHER]: 'Other'
-}
+  [ReferenceType.JOURNAL_ARTICLE]: "Journal Article",
+  [ReferenceType.BOOK]: "Book",
+  [ReferenceType.BOOK_CHAPTER]: "Book Chapter",
+  [ReferenceType.CONFERENCE_PAPER]: "Conference Paper",
+  [ReferenceType.THESIS]: "Thesis",
+  [ReferenceType.WEBSITE]: "Website",
+  [ReferenceType.REPORT]: "Report",
+  [ReferenceType.PATENT]: "Patent",
+  [ReferenceType.OTHER]: "Other",
+};
 
 /**
  * Mapping of reference types to icon components
  */
-const REFERENCE_TYPE_ICONS: Record<ReferenceType, React.ComponentType<{ className?: string }>> = {
+const REFERENCE_TYPE_ICONS: Record<
+  ReferenceType,
+  React.ComponentType<{ className?: string }>
+> = {
   [ReferenceType.JOURNAL_ARTICLE]: FileText,
   [ReferenceType.BOOK]: BookOpen,
   [ReferenceType.BOOK_CHAPTER]: BookOpen,
@@ -95,26 +104,26 @@ const REFERENCE_TYPE_ICONS: Record<ReferenceType, React.ComponentType<{ classNam
   [ReferenceType.WEBSITE]: Globe,
   [ReferenceType.REPORT]: Briefcase,
   [ReferenceType.PATENT]: Shield,
-  [ReferenceType.OTHER]: MoreHorizontal
-}
+  [ReferenceType.OTHER]: MoreHorizontal,
+};
 
 /**
  * Mapping of citation styles to display labels
  */
 const CITATION_STYLE_LABELS: Record<CitationStyle, string> = {
-  [CitationStyle.APA]: 'APA (7th Edition)',
-  [CitationStyle.MLA]: 'MLA (9th Edition)',
-  [CitationStyle.CHICAGO]: 'Chicago (17th Edition)',
-  [CitationStyle.HARVARD]: 'Harvard',
-  [CitationStyle.IEEE]: 'IEEE',
-  [CitationStyle.VANCOUVER]: 'Vancouver'
-}
+  [CitationStyle.APA]: "APA (7th Edition)",
+  [CitationStyle.MLA]: "MLA (9th Edition)",
+  [CitationStyle.CHICAGO]: "Chicago (17th Edition)",
+  [CitationStyle.HARVARD]: "Harvard",
+  [CitationStyle.IEEE]: "IEEE",
+  [CitationStyle.VANCOUVER]: "Vancouver",
+};
 
 /**
  * A detailed view component for displaying and managing a single reference.
  * This component provides a comprehensive interface for viewing reference details,
  * managing tags, previewing citations in different styles, and editing or deleting the reference.
- * 
+ *
  * @param {ReferenceDetailProps} props - The props for the ReferenceDetail component
  * @param {Reference} props.reference - The reference to display
  * @param {(reference: Reference) => void} props.onEdit - Callback function called when the edit button is clicked
@@ -123,7 +132,7 @@ const CITATION_STYLE_LABELS: Record<CitationStyle, string> = {
  * @param {(referenceId: string, tag: string) => void} props.onTagRemove - Callback function called when a tag is removed
  * @param {() => void} props.onClose - Callback function called when the close button is clicked
  * @param {boolean} [props.isLoading=false] - Whether the component is in a loading state
- * 
+ *
  * @example
  * ```tsx
  * <ReferenceDetail
@@ -143,159 +152,174 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
   onTagAdd,
   onTagRemove,
   onClose,
-  isLoading = false
+  isLoading = false,
 }) => {
   const [state, setState] = useState<ReferenceDetailState>({
     editingTags: false,
-    newTag: '',
+    newTag: "",
     selectedCitationStyle: CitationStyle.APA,
-    showDeleteConfirmation: false
-  })
+    showDeleteConfirmation: false,
+  });
 
-  const IconComponent = REFERENCE_TYPE_ICONS[reference.type]
+  const IconComponent = REFERENCE_TYPE_ICONS[reference.type];
 
   const formatAuthors = (authors: Author[]): string => {
-    if (authors.length === 0) return 'No authors'
+    if (authors.length === 0) return "No authors";
     if (authors.length === 1) {
-      const author = authors[0]
-      return `${author.firstName} ${author.middleName ? author.middleName + ' ' : ''}${author.lastName}${author.suffix ? ', ' + author.suffix : ''}`
+      const author = authors[0];
+      return `${author.firstName} ${author.middleName ? author.middleName + " " : ""}${author.lastName}${author.suffix ? ", " + author.suffix : ""}`;
     }
     if (authors.length === 2) {
-      return `${authors[0].firstName} ${authors[0].lastName} & ${authors[1].firstName} ${authors[1].lastName}`
+      return `${authors[0].firstName} ${authors[0].lastName} & ${authors[1].firstName} ${authors[1].lastName}`;
     }
-    return `${authors[0].firstName} ${authors[0].lastName} et al.`
-  }
+    return `${authors[0].firstName} ${authors[0].lastName} et al.`;
+  };
 
   const formatDate = (date: Date | undefined): string => {
-    if (!date) return 'No date'
-    return new Date(date).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    })
-  }
-
-
+    if (!date) return "No date";
+    return new Date(date).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  };
 
   const generateCitation = (style: CitationStyle): string => {
-    const authors = reference.authors
-    const year = reference.publicationDate ? new Date(reference.publicationDate).getFullYear() : 'n.d.'
-    const title = reference.title
+    const authors = reference.authors;
+    const year = reference.publicationDate
+      ? new Date(reference.publicationDate).getFullYear()
+      : "n.d.";
+    const title = reference.title;
 
     switch (style) {
       case CitationStyle.APA:
         if (authors.length === 0) {
-          return `${title} (${year}).`
+          return `${title} (${year}).`;
         } else if (authors.length === 1) {
-          const author = authors[0]
-          return `${author.lastName}, ${author.firstName[0]}. (${year}). ${title}.`
+          const author = authors[0];
+          return `${author.lastName}, ${author.firstName[0]}. (${year}). ${title}.`;
         } else if (authors.length <= 20) {
-          const authorList = authors.map(a => `${a.lastName}, ${a.firstName[0]}.`).join(', ')
-          return `${authorList} (${year}). ${title}.`
+          const authorList = authors
+            .map((a) => `${a.lastName}, ${a.firstName[0]}.`)
+            .join(", ");
+          return `${authorList} (${year}). ${title}.`;
         } else {
-          const firstAuthor = authors[0]
-          return `${firstAuthor.lastName}, ${firstAuthor.firstName[0]}., et al. (${year}). ${title}.`
+          const firstAuthor = authors[0];
+          return `${firstAuthor.lastName}, ${firstAuthor.firstName[0]}., et al. (${year}). ${title}.`;
         }
 
       case CitationStyle.MLA:
         if (authors.length === 0) {
-          return `"${title}." ${year}.`
+          return `"${title}." ${year}.`;
         } else if (authors.length === 1) {
-          const author = authors[0]
-          return `${author.lastName}, ${author.firstName}. "${title}." ${year}.`
+          const author = authors[0];
+          return `${author.lastName}, ${author.firstName}. "${title}." ${year}.`;
         } else if (authors.length === 2) {
-          return `${authors[0].lastName}, ${authors[0].firstName}, and ${authors[1].firstName} ${authors[1].lastName}. "${title}." ${year}.`
+          return `${authors[0].lastName}, ${authors[0].firstName}, and ${authors[1].firstName} ${authors[1].lastName}. "${title}." ${year}.`;
         } else {
-          const firstAuthor = authors[0]
-          return `${firstAuthor.lastName}, ${firstAuthor.firstName}, et al. "${title}." ${year}.`
+          const firstAuthor = authors[0];
+          return `${firstAuthor.lastName}, ${firstAuthor.firstName}, et al. "${title}." ${year}.`;
         }
 
       case CitationStyle.CHICAGO:
         if (authors.length === 0) {
-          return `"${title}." ${year}.`
+          return `"${title}." ${year}.`;
         } else if (authors.length === 1) {
-          const author = authors[0]
-          return `${author.lastName}, ${author.firstName}. "${title}." ${year}.`
+          const author = authors[0];
+          return `${author.lastName}, ${author.firstName}. "${title}." ${year}.`;
         } else {
-          const authorList = authors.map((a, i) => 
-            i === 0 ? `${a.lastName}, ${a.firstName}` : `${a.firstName} ${a.lastName}`
-          ).join(', ')
-          return `${authorList}. "${title}." ${year}.`
+          const authorList = authors
+            .map((a, i) =>
+              i === 0
+                ? `${a.lastName}, ${a.firstName}`
+                : `${a.firstName} ${a.lastName}`,
+            )
+            .join(", ");
+          return `${authorList}. "${title}." ${year}.`;
         }
 
       case CitationStyle.HARVARD:
         if (authors.length === 0) {
-          return `${title} ${year}.`
+          return `${title} ${year}.`;
         } else if (authors.length === 1) {
-          const author = authors[0]
-          return `${author.lastName}, ${author.firstName[0]} ${year}, '${title}'.`
+          const author = authors[0];
+          return `${author.lastName}, ${author.firstName[0]} ${year}, '${title}'.`;
         } else {
-          const authorList = authors.map(a => `${a.lastName}, ${a.firstName[0]}`).join(', ')
-          return `${authorList} ${year}, '${title}'.`
+          const authorList = authors
+            .map((a) => `${a.lastName}, ${a.firstName[0]}`)
+            .join(", ");
+          return `${authorList} ${year}, '${title}'.`;
         }
 
       case CitationStyle.IEEE:
         if (authors.length === 0) {
-          return `"${title}," ${year}.`
+          return `"${title}," ${year}.`;
         } else {
-          const authorList = authors.map(a => `${a.firstName[0]}. ${a.lastName}`).join(', ')
-          return `${authorList}, "${title}," ${year}.`
+          const authorList = authors
+            .map((a) => `${a.firstName[0]}. ${a.lastName}`)
+            .join(", ");
+          return `${authorList}, "${title}," ${year}.`;
         }
 
       case CitationStyle.VANCOUVER:
         if (authors.length === 0) {
-          return `${title}. ${year}.`
+          return `${title}. ${year}.`;
         } else if (authors.length <= 6) {
-          const authorList = authors.map(a => `${a.lastName} ${a.firstName[0]}`).join(', ')
-          return `${authorList}. ${title}. ${year}.`
+          const authorList = authors
+            .map((a) => `${a.lastName} ${a.firstName[0]}`)
+            .join(", ");
+          return `${authorList}. ${title}. ${year}.`;
         } else {
-          const firstThree = authors.slice(0, 3).map(a => `${a.lastName} ${a.firstName[0]}`).join(', ')
-          return `${firstThree}, et al. ${title}. ${year}.`
+          const firstThree = authors
+            .slice(0, 3)
+            .map((a) => `${a.lastName} ${a.firstName[0]}`)
+            .join(", ");
+          return `${firstThree}, et al. ${title}. ${year}.`;
         }
 
       default:
-        return `${formatAuthors(authors)} (${year}). ${title}.`
+        return `${formatAuthors(authors)} (${year}). ${title}.`;
     }
-  }
+  };
 
   const handleAddTag = () => {
     if (state.newTag.trim()) {
-      onTagAdd(reference.id, state.newTag.trim())
-      setState(prev => ({ ...prev, newTag: '' }))
-      toast.success('Tag added successfully')
+      onTagAdd(reference.id, state.newTag.trim());
+      setState((prev) => ({ ...prev, newTag: "" }));
+      toast.success("Tag added successfully");
     }
-  }
+  };
 
   const handleRemoveTag = (tag: string) => {
-    onTagRemove(reference.id, tag)
-    toast.success('Tag removed successfully')
-  }
+    onTagRemove(reference.id, tag);
+    toast.success("Tag removed successfully");
+  };
 
   const handleCopyCitation = () => {
-    const citation = generateCitation(state.selectedCitationStyle)
-    navigator.clipboard.writeText(citation)
-    toast.success('Citation copied to clipboard')
-  }
+    const citation = generateCitation(state.selectedCitationStyle);
+    navigator.clipboard.writeText(citation);
+    toast.success("Citation copied to clipboard");
+  };
 
   const handleExternalLink = () => {
     if (reference.url) {
-      window.open(reference.url, '_blank', 'noopener,noreferrer')
+      window.open(reference.url, "_blank", "noopener,noreferrer");
     }
-  }
+  };
 
   const handleDelete = () => {
-    setState(prev => ({ ...prev, showDeleteConfirmation: true }))
-  }
+    setState((prev) => ({ ...prev, showDeleteConfirmation: true }));
+  };
 
   const confirmDelete = () => {
-    onDelete(reference.id)
-    setState(prev => ({ ...prev, showDeleteConfirmation: false }))
-    toast.success('Reference deleted successfully')
-  }
+    onDelete(reference.id);
+    setState((prev) => ({ ...prev, showDeleteConfirmation: false }));
+    toast.success("Reference deleted successfully");
+  };
 
   const cancelDelete = () => {
-    setState(prev => ({ ...prev, showDeleteConfirmation: false }))
-  }
+    setState((prev) => ({ ...prev, showDeleteConfirmation: false }));
+  };
 
   return (
     <div className="flex flex-col h-full bg-background">
@@ -304,7 +328,9 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
         <div className="flex items-center gap-3">
           <IconComponent className="h-6 w-6 text-muted-foreground" />
           <div>
-            <h2 className="text-xl font-semibold line-clamp-1">{reference.title}</h2>
+            <h2 className="text-xl font-semibold line-clamp-1">
+              {reference.title}
+            </h2>
             <p className="text-sm text-muted-foreground">
               {REFERENCE_TYPE_LABELS[reference.type]}
             </p>
@@ -331,6 +357,7 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
             Delete
           </Button>
           <Button
+            aria-label="Close"
             variant="ghost"
             size="sm"
             onClick={onClose}
@@ -345,31 +372,39 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
           {/* Basic Information */}
           <div className="space-y-4">
             <h3 className="text-lg font-medium">Basic Information</h3>
-            
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <Label className="text-sm font-medium text-muted-foreground">Title</Label>
-                <p className="mt-1 text-sm">{reference.title || 'No title'}</p>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Title
+                </Label>
+                <p className="mt-1 text-sm">{reference.title || "No title"}</p>
               </div>
-              
+
               <div>
-                <Label className="text-sm font-medium text-muted-foreground">Authors</Label>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Authors
+                </Label>
                 <p className="mt-1 text-sm flex items-center gap-2">
                   <Users className="h-4 w-4" />
                   {formatAuthors(reference.authors)}
                 </p>
               </div>
-              
+
               <div>
-                <Label className="text-sm font-medium text-muted-foreground">Publication Date</Label>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Publication Date
+                </Label>
                 <p className="mt-1 text-sm flex items-center gap-2">
                   <Calendar className="h-4 w-4" />
                   {formatDate(reference.publicationDate)}
                 </p>
               </div>
-              
+
               <div>
-                <Label className="text-sm font-medium text-muted-foreground">Type</Label>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Type
+                </Label>
                 <Badge variant="outline" className="mt-1">
                   {REFERENCE_TYPE_LABELS[reference.type]}
                 </Badge>
@@ -382,46 +417,58 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
           {/* Publication Details */}
           <div className="space-y-4">
             <h3 className="text-lg font-medium">Publication Details</h3>
-            
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {reference.journal && (
                 <div>
-                  <Label className="text-sm font-medium text-muted-foreground">Journal/Conference</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    Journal/Conference
+                  </Label>
                   <p className="mt-1 text-sm">{reference.journal}</p>
                 </div>
               )}
-              
+
               {reference.publisher && (
                 <div>
-                  <Label className="text-sm font-medium text-muted-foreground">Publisher</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    Publisher
+                  </Label>
                   <p className="mt-1 text-sm">{reference.publisher}</p>
                 </div>
               )}
-              
+
               {reference.volume && (
                 <div>
-                  <Label className="text-sm font-medium text-muted-foreground">Volume</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    Volume
+                  </Label>
                   <p className="mt-1 text-sm">{reference.volume}</p>
                 </div>
               )}
-              
+
               {reference.issue && (
                 <div>
-                  <Label className="text-sm font-medium text-muted-foreground">Issue</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    Issue
+                  </Label>
                   <p className="mt-1 text-sm">{reference.issue}</p>
                 </div>
               )}
-              
+
               {reference.pages && (
                 <div>
-                  <Label className="text-sm font-medium text-muted-foreground">Pages</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    Pages
+                  </Label>
                   <p className="mt-1 text-sm">{reference.pages}</p>
                 </div>
               )}
-              
+
               {reference.edition && (
                 <div>
-                  <Label className="text-sm font-medium text-muted-foreground">Edition</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    Edition
+                  </Label>
                   <p className="mt-1 text-sm">{reference.edition}</p>
                 </div>
               )}
@@ -433,17 +480,24 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
           {/* Identifiers */}
           <div className="space-y-4">
             <h3 className="text-lg font-medium">Identifiers</h3>
-            
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {reference.doi && (
                 <div>
-                  <Label className="text-sm font-medium text-muted-foreground">DOI</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    DOI
+                  </Label>
                   <div className="mt-1 flex items-center gap-2">
                     <p className="text-sm font-mono">{reference.doi}</p>
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => window.open(`https://doi.org/${reference.doi}`, '_blank')}
+                      onClick={() =>
+                        window.open(
+                          `https://doi.org/${reference.doi}`,
+                          "_blank",
+                        )
+                      }
                       className="h-6 w-6 p-0"
                     >
                       <ExternalLink className="h-3 w-3" />
@@ -451,20 +505,27 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
                   </div>
                 </div>
               )}
-              
+
               {reference.isbn && (
                 <div>
-                  <Label className="text-sm font-medium text-muted-foreground">ISBN</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    ISBN
+                  </Label>
                   <p className="mt-1 text-sm font-mono">{reference.isbn}</p>
                 </div>
               )}
-              
+
               {reference.url && (
                 <div className="md:col-span-2">
-                  <Label className="text-sm font-medium text-muted-foreground">URL</Label>
+                  <Label className="text-sm font-medium text-muted-foreground">
+                    URL
+                  </Label>
                   <div className="mt-1 flex items-center gap-2">
-                    <p className="text-sm font-mono truncate flex-1">{reference.url}</p>
+                    <p className="text-sm font-mono truncate flex-1">
+                      {reference.url}
+                    </p>
                     <Button
+                      aria-label="Open external link"
                       variant="ghost"
                       size="sm"
                       onClick={handleExternalLink}
@@ -487,13 +548,18 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => setState(prev => ({ ...prev, editingTags: !prev.editingTags }))}
+                onClick={() =>
+                  setState((prev) => ({
+                    ...prev,
+                    editingTags: !prev.editingTags,
+                  }))
+                }
               >
                 <Tag className="h-4 w-4 mr-2" />
-                {state.editingTags ? 'Done' : 'Manage Tags'}
+                {state.editingTags ? "Done" : "Manage Tags"}
               </Button>
             </div>
-            
+
             <div className="space-y-3">
               <div className="flex flex-wrap gap-2">
                 {reference.tags.map((tag) => (
@@ -513,14 +579,16 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
                   <p className="text-sm text-muted-foreground">No tags added</p>
                 )}
               </div>
-              
+
               {state.editingTags && (
                 <div className="flex gap-2">
                   <Input
                     placeholder="Add new tag..."
                     value={state.newTag}
-                    onChange={(e) => setState(prev => ({ ...prev, newTag: e.target.value }))}
-                    onKeyPress={(e) => e.key === 'Enter' && handleAddTag()}
+                    onChange={(e) =>
+                      setState((prev) => ({ ...prev, newTag: e.target.value }))
+                    }
+                    onKeyPress={(e) => e.key === "Enter" && handleAddTag()}
                     className="flex-1"
                   />
                   <Button onClick={handleAddTag} size="sm">
@@ -536,35 +604,41 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
           {/* Citation Preview */}
           <div className="space-y-4">
             <h3 className="text-lg font-medium">Citation Preview</h3>
-            
+
             <div className="space-y-3">
               <div className="flex items-center gap-3">
                 <Label className="text-sm font-medium">Citation Style</Label>
                 <Select
                   value={state.selectedCitationStyle}
-                  onValueChange={(value: CitationStyle) => 
-                    setState(prev => ({ ...prev, selectedCitationStyle: value }))
+                  onValueChange={(value: CitationStyle) =>
+                    setState((prev) => ({
+                      ...prev,
+                      selectedCitationStyle: value,
+                    }))
                   }
                 >
                   <SelectTrigger className="w-[200px]">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {Object.entries(CITATION_STYLE_LABELS).map(([value, label]) => (
-                      <SelectItem key={value} value={value}>
-                        {label}
-                      </SelectItem>
-                    ))}
+                    {Object.entries(CITATION_STYLE_LABELS).map(
+                      ([value, label]) => (
+                        <SelectItem key={value} value={value}>
+                          {label}
+                        </SelectItem>
+                      ),
+                    )}
                   </SelectContent>
                 </Select>
               </div>
-              
+
               <div className="p-4 bg-muted rounded-lg">
                 <div className="flex items-start justify-between gap-3">
                   <p className="text-sm font-mono leading-relaxed flex-1">
                     {generateCitation(state.selectedCitationStyle)}
                   </p>
                   <Button
+                    aria-label="Copy citation"
                     variant="ghost"
                     size="sm"
                     onClick={handleCopyCitation}
@@ -584,7 +658,9 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
               <div className="space-y-4">
                 <h3 className="text-lg font-medium">Notes</h3>
                 <div className="p-4 bg-muted rounded-lg">
-                  <p className="text-sm whitespace-pre-wrap">{reference.notes}</p>
+                  <p className="text-sm whitespace-pre-wrap">
+                    {reference.notes}
+                  </p>
                 </div>
               </div>
             </>
@@ -594,25 +670,29 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
           <Separator />
           <div className="space-y-4">
             <h3 className="text-lg font-medium">Metadata</h3>
-            
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-muted-foreground">
               <div>
                 <Label className="text-xs font-medium">Created</Label>
                 <p className="mt-1">{formatDate(reference.createdAt)}</p>
               </div>
-              
+
               <div>
                 <Label className="text-xs font-medium">Last Modified</Label>
                 <p className="mt-1">{formatDate(reference.updatedAt)}</p>
               </div>
-              
+
               <div>
-                <Label className="text-xs font-medium">Metadata Confidence</Label>
+                <Label className="text-xs font-medium">
+                  Metadata Confidence
+                </Label>
                 <div className="mt-1 flex items-center gap-2">
                   <div className="flex-1 bg-muted rounded-full h-2">
-                    <div 
-                      className="bg-primary h-2 rounded-full transition-all" 
-                      style={{ width: `${reference.metadataConfidence * 100}%` }}
+                    <div
+                      className="bg-primary h-2 rounded-full transition-all"
+                      style={{
+                        width: `${reference.metadataConfidence * 100}%`,
+                      }}
                     />
                   </div>
                   <span className="text-xs">
@@ -631,7 +711,8 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
           <div className="bg-background p-6 rounded-lg shadow-lg max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold mb-4">Delete Reference</h3>
             <p className="text-sm text-muted-foreground mb-6">
-              Are you sure you want to delete this reference? This action cannot be undone.
+              Are you sure you want to delete this reference? This action cannot
+              be undone.
             </p>
             <div className="flex justify-end gap-3">
               <Button variant="outline" onClick={cancelDelete}>
@@ -645,5 +726,5 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
         </div>
       )}
     </div>
-  )
-}
+  );
+};

--- a/src/components/ui/reference-form.tsx
+++ b/src/components/ui/reference-form.tsx
@@ -1,44 +1,50 @@
-"use client"
+"use client";
 
-import React, { useState, useEffect } from "react"
-import { Button } from "./shadcn/button"
-import { Input } from "./shadcn/input"
-import { Label } from "./shadcn/label"
-import { Textarea } from "./shadcn/textarea"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./shadcn/select"
-import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card"
-import { Badge } from "./shadcn/badge"
-import { CitationStyle, Reference, ReferenceType } from "../../lib/ai-types"
-import { X, Plus } from "lucide-react"
+import React, { useState, useEffect } from "react";
+import { Button } from "./shadcn/button";
+import { Input } from "./shadcn/input";
+import { Label } from "./shadcn/label";
+import { Textarea } from "./shadcn/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./shadcn/select";
+import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card";
+import { Badge } from "./shadcn/badge";
+import { CitationStyle, Reference, ReferenceType } from "../../lib/ai-types";
+import { X, Plus } from "lucide-react";
 
 /**
  * Props for the ReferenceForm component
  */
 interface ReferenceFormProps {
   /** The ID of the conversation this reference belongs to */
-  conversationId: string
+  conversationId: string;
   /** The ID of the reference being edited (optional) */
-  referenceId?: string
+  referenceId?: string;
   /** Callback function to close the form */
-  onClose: () => void
+  onClose: () => void;
   /** The citation style to use for the reference */
-  citationStyle: CitationStyle
+  citationStyle: CitationStyle;
   /** Prefilled data for the form (optional) */
-  prefilledData?: Partial<Reference>
+  prefilledData?: Partial<Reference>;
 }
 
 /**
  * A form component for creating and editing references.
  * This component provides a comprehensive interface for managing academic references
  * with support for different reference types and metadata fields.
- * 
+ *
  * @param {ReferenceFormProps} props - The props for the ReferenceForm component
  * @param {string} props.conversationId - The ID of the conversation this reference belongs to
  * @param {string} [props.referenceId] - The ID of the reference being edited
  * @param {() => void} props.onClose - Callback function to close the form
  * @param {CitationStyle} props.citationStyle - The citation style to use for the reference
  * @param {Partial<Reference>} [props.prefilledData] - Prefilled data for the form
- * 
+ *
  * @example
  * ```tsx
  * <ReferenceForm
@@ -47,7 +53,7 @@ interface ReferenceFormProps {
  *   citationStyle={CitationStyle.APA}
  * />
  * ```
- * 
+ *
  * @example
  * ```tsx
  * <ReferenceForm
@@ -64,114 +70,117 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
   referenceId,
   onClose,
   citationStyle,
-  prefilledData
+  prefilledData,
 }) => {
   const [formData, setFormData] = useState<Partial<Reference>>({
     type: ReferenceType.JOURNAL_ARTICLE,
-    title: '',
+    title: "",
     authors: [],
-    publication_date: '',
-    url: '',
-    doi: '',
-    journal: '',
-    volume: '',
-    issue: '',
-    pages: '',
-    publisher: '',
-    isbn: '',
-    edition: '',
-    chapter: '',
-    editor: '',
-    access_date: '',
-    notes: '',
-    tags: []
-  })
+    publication_date: "",
+    url: "",
+    doi: "",
+    journal: "",
+    volume: "",
+    issue: "",
+    pages: "",
+    publisher: "",
+    isbn: "",
+    edition: "",
+    chapter: "",
+    editor: "",
+    access_date: "",
+    notes: "",
+    tags: [],
+  });
 
-  const [authorInput, setAuthorInput] = useState('')
-  const [tagInput, setTagInput] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [isEditing, setIsEditing] = useState(false)
+  const [authorInput, setAuthorInput] = useState("");
+  const [tagInput, setTagInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   // Load existing reference if editing or prefilled data if provided
   useEffect(() => {
     if (referenceId) {
-      loadReference()
+      loadReference();
     } else if (prefilledData) {
-      setFormData(prev => ({
+      setFormData((prev) => ({
         ...prev,
-        ...prefilledData
-      }))
+        ...prefilledData,
+      }));
     }
-  }, [referenceId, prefilledData])
+  }, [referenceId, prefilledData]);
 
   const loadReference = async () => {
     try {
-      const stored = localStorage.getItem(`references_${conversationId}`)
+      const stored = localStorage.getItem(`references_${conversationId}`);
       if (stored) {
-        const references: Reference[] = JSON.parse(stored)
-        const reference = references.find(ref => ref.id === referenceId)
+        const references: Reference[] = JSON.parse(stored);
+        const reference = references.find((ref) => ref.id === referenceId);
         if (reference) {
-          setFormData(reference)
-          setIsEditing(true)
+          setFormData(reference);
+          setIsEditing(true);
         }
       }
     } catch (error) {
-      console.error('Error loading reference:', error)
+      console.error("Error loading reference:", error);
     }
-  }
+  };
 
-  const handleInputChange = (field: keyof Reference, value: string | string[]) => {
-    setFormData(prev => ({
+  const handleInputChange = (
+    field: keyof Reference,
+    value: string | string[],
+  ) => {
+    setFormData((prev) => ({
       ...prev,
-      [field]: value
-    }))
-  }
+      [field]: value,
+    }));
+  };
 
   const addAuthor = () => {
     if (authorInput.trim()) {
-      setFormData(prev => ({
+      setFormData((prev) => ({
         ...prev,
-        authors: [...(prev.authors || []), authorInput.trim()]
-      }))
-      setAuthorInput('')
+        authors: [...(prev.authors || []), authorInput.trim()],
+      }));
+      setAuthorInput("");
     }
-  }
+  };
 
   const removeAuthor = (index: number) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      authors: (prev.authors || []).filter((_, i) => i !== index)
-    }))
-  }
+      authors: (prev.authors || []).filter((_, i) => i !== index),
+    }));
+  };
 
   const addTag = () => {
     if (tagInput.trim()) {
-      setFormData(prev => ({
+      setFormData((prev) => ({
         ...prev,
-        tags: [...(prev.tags || []), tagInput.trim()]
-      }))
-      setTagInput('')
+        tags: [...(prev.tags || []), tagInput.trim()],
+      }));
+      setTagInput("");
     }
-  }
+  };
 
   const removeTag = (index: number) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      tags: (prev.tags || []).filter((_, i) => i !== index)
-    }))
-  }
+      tags: (prev.tags || []).filter((_, i) => i !== index),
+    }));
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setLoading(true)
+    e.preventDefault();
+    setLoading(true);
 
     try {
-      const now = new Date().toISOString()
+      const now = new Date().toISOString();
       const reference: Reference = {
         id: formData.id || `ref_${Date.now()}`,
         conversation_id: conversationId,
         type: formData.type || ReferenceType.JOURNAL_ARTICLE,
-        title: formData.title || '',
+        title: formData.title || "",
         authors: formData.authors || [],
         publication_date: formData.publication_date,
         url: formData.url,
@@ -192,44 +201,53 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
         ai_confidence: 0.8,
         ai_relevance_score: 0,
         created_at: isEditing ? formData.created_at || now : now,
-        updated_at: now
-      }
+        updated_at: now,
+      };
 
       // Get existing references
-      const stored = localStorage.getItem(`references_${conversationId}`)
-      let references: Reference[] = stored ? JSON.parse(stored) : []
+      const stored = localStorage.getItem(`references_${conversationId}`);
+      let references: Reference[] = stored ? JSON.parse(stored) : [];
 
       if (isEditing) {
         // Update existing reference
-        references = references.map(ref =>
-          ref.id === referenceId ? reference : ref
-        )
+        references = references.map((ref) =>
+          ref.id === referenceId ? reference : ref,
+        );
       } else {
         // Add new reference
-        references.push(reference)
+        references.push(reference);
       }
 
       // Save to localStorage
-      localStorage.setItem(`references_${conversationId}`, JSON.stringify(references))
+      localStorage.setItem(
+        `references_${conversationId}`,
+        JSON.stringify(references),
+      );
 
-      onClose()
+      onClose();
     } catch (error) {
-      console.error('Error saving reference:', error)
+      console.error("Error saving reference:", error);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
-  const isFormValid = formData.title && formData.authors && formData.authors.length > 0
+  const isFormValid =
+    formData.title && formData.authors && formData.authors.length > 0;
 
   return (
     <Card className="w-full max-w-2xl mx-auto">
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle>
-            {isEditing ? 'Edit Reference' : 'Add New Reference'}
+            {isEditing ? "Edit Reference" : "Add New Reference"}
           </CardTitle>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button
+            aria-label="Close"
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+          >
             <X className="h-4 w-4" />
           </Button>
         </div>
@@ -242,17 +260,27 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               <Label htmlFor="type">Reference Type</Label>
               <Select
                 value={formData.type}
-                onValueChange={(value) => handleInputChange('type', value as ReferenceType)}
+                onValueChange={(value) =>
+                  handleInputChange("type", value as ReferenceType)
+                }
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={ReferenceType.JOURNAL_ARTICLE}>Journal Article</SelectItem>
+                  <SelectItem value={ReferenceType.JOURNAL_ARTICLE}>
+                    Journal Article
+                  </SelectItem>
                   <SelectItem value={ReferenceType.BOOK}>Book</SelectItem>
-                  <SelectItem value={ReferenceType.BOOK_CHAPTER}>Book Chapter</SelectItem>
-                  <SelectItem value={ReferenceType.CONFERENCE_PAPER}>Conference Paper</SelectItem>
-                  <SelectItem value={ReferenceType.THESIS}>Thesis/Dissertation</SelectItem>
+                  <SelectItem value={ReferenceType.BOOK_CHAPTER}>
+                    Book Chapter
+                  </SelectItem>
+                  <SelectItem value={ReferenceType.CONFERENCE_PAPER}>
+                    Conference Paper
+                  </SelectItem>
+                  <SelectItem value={ReferenceType.THESIS}>
+                    Thesis/Dissertation
+                  </SelectItem>
                   <SelectItem value={ReferenceType.WEBSITE}>Website</SelectItem>
                   <SelectItem value={ReferenceType.REPORT}>Report</SelectItem>
                   <SelectItem value={ReferenceType.PATENT}>Patent</SelectItem>
@@ -265,8 +293,8 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               <Label htmlFor="title">Title *</Label>
               <Input
                 id="title"
-                value={formData.title || ''}
-                onChange={(e) => handleInputChange('title', e.target.value)}
+                value={formData.title || ""}
+                onChange={(e) => handleInputChange("title", e.target.value)}
                 placeholder="Enter the title of the reference"
                 required
               />
@@ -280,7 +308,9 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   value={authorInput}
                   onChange={(e) => setAuthorInput(e.target.value)}
                   placeholder="Add author name"
-                  onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addAuthor())}
+                  onKeyPress={(e) =>
+                    e.key === "Enter" && (e.preventDefault(), addAuthor())
+                  }
                 />
                 <Button type="button" onClick={addAuthor} size="sm">
                   <Plus className="h-4 w-4" />
@@ -288,8 +318,14 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               </div>
               <div className="flex flex-wrap gap-2">
                 {(formData.authors || []).map((author, index) => (
-                  <Badge key={index} variant="secondary" className="flex items-center gap-1">
-                    {typeof author === 'string' ? author : `${author.firstName} ${author.lastName}`}
+                  <Badge
+                    key={index}
+                    variant="secondary"
+                    className="flex items-center gap-1"
+                  >
+                    {typeof author === "string"
+                      ? author
+                      : `${author.firstName} ${author.lastName}`}
                     <button
                       type="button"
                       onClick={() => removeAuthor(index)}
@@ -307,8 +343,10 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               <Input
                 id="publication_date"
                 type="date"
-                value={formData.publication_date || ''}
-                onChange={(e) => handleInputChange('publication_date', e.target.value)}
+                value={formData.publication_date || ""}
+                onChange={(e) =>
+                  handleInputChange("publication_date", e.target.value)
+                }
               />
             </div>
           </div>
@@ -317,14 +355,17 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
           <div className="space-y-4">
             <h3 className="text-lg font-semibold">Publication Details</h3>
 
-            {(formData.type === ReferenceType.JOURNAL_ARTICLE || formData.type === ReferenceType.CONFERENCE_PAPER) && (
+            {(formData.type === ReferenceType.JOURNAL_ARTICLE ||
+              formData.type === ReferenceType.CONFERENCE_PAPER) && (
               <>
                 <div>
                   <Label htmlFor="journal">Journal/Conference Name</Label>
                   <Input
                     id="journal"
-                    value={formData.journal || ''}
-                    onChange={(e) => handleInputChange('journal', e.target.value)}
+                    value={formData.journal || ""}
+                    onChange={(e) =>
+                      handleInputChange("journal", e.target.value)
+                    }
                   />
                 </div>
                 <div className="grid grid-cols-2 gap-4">
@@ -332,16 +373,20 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                     <Label htmlFor="volume">Volume</Label>
                     <Input
                       id="volume"
-                      value={formData.volume || ''}
-                      onChange={(e) => handleInputChange('volume', e.target.value)}
+                      value={formData.volume || ""}
+                      onChange={(e) =>
+                        handleInputChange("volume", e.target.value)
+                      }
                     />
                   </div>
                   <div>
                     <Label htmlFor="issue">Issue</Label>
                     <Input
                       id="issue"
-                      value={formData.issue || ''}
-                      onChange={(e) => handleInputChange('issue', e.target.value)}
+                      value={formData.issue || ""}
+                      onChange={(e) =>
+                        handleInputChange("issue", e.target.value)
+                      }
                     />
                   </div>
                 </div>
@@ -349,22 +394,25 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   <Label htmlFor="pages">Pages</Label>
                   <Input
                     id="pages"
-                    value={formData.pages || ''}
-                    onChange={(e) => handleInputChange('pages', e.target.value)}
+                    value={formData.pages || ""}
+                    onChange={(e) => handleInputChange("pages", e.target.value)}
                     placeholder="e.g., 123-145"
                   />
                 </div>
               </>
             )}
 
-            {(formData.type === ReferenceType.BOOK || formData.type === ReferenceType.BOOK_CHAPTER) && (
+            {(formData.type === ReferenceType.BOOK ||
+              formData.type === ReferenceType.BOOK_CHAPTER) && (
               <>
                 <div>
                   <Label htmlFor="publisher">Publisher</Label>
                   <Input
                     id="publisher"
-                    value={formData.publisher || ''}
-                    onChange={(e) => handleInputChange('publisher', e.target.value)}
+                    value={formData.publisher || ""}
+                    onChange={(e) =>
+                      handleInputChange("publisher", e.target.value)
+                    }
                   />
                 </div>
                 {formData.type === ReferenceType.BOOK && (
@@ -373,16 +421,20 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       <Label htmlFor="isbn">ISBN</Label>
                       <Input
                         id="isbn"
-                        value={formData.isbn || ''}
-                        onChange={(e) => handleInputChange('isbn', e.target.value)}
+                        value={formData.isbn || ""}
+                        onChange={(e) =>
+                          handleInputChange("isbn", e.target.value)
+                        }
                       />
                     </div>
                     <div>
                       <Label htmlFor="edition">Edition</Label>
                       <Input
                         id="edition"
-                        value={formData.edition || ''}
-                        onChange={(e) => handleInputChange('edition', e.target.value)}
+                        value={formData.edition || ""}
+                        onChange={(e) =>
+                          handleInputChange("edition", e.target.value)
+                        }
                       />
                     </div>
                   </>
@@ -393,16 +445,20 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       <Label htmlFor="chapter">Chapter Title</Label>
                       <Input
                         id="chapter"
-                        value={formData.chapter || ''}
-                        onChange={(e) => handleInputChange('chapter', e.target.value)}
+                        value={formData.chapter || ""}
+                        onChange={(e) =>
+                          handleInputChange("chapter", e.target.value)
+                        }
                       />
                     </div>
                     <div>
                       <Label htmlFor="editor">Editor(s)</Label>
                       <Input
                         id="editor"
-                        value={formData.editor || ''}
-                        onChange={(e) => handleInputChange('editor', e.target.value)}
+                        value={formData.editor || ""}
+                        onChange={(e) =>
+                          handleInputChange("editor", e.target.value)
+                        }
                       />
                     </div>
                   </>
@@ -414,8 +470,8 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               <Label htmlFor="doi">DOI</Label>
               <Input
                 id="doi"
-                value={formData.doi || ''}
-                onChange={(e) => handleInputChange('doi', e.target.value)}
+                value={formData.doi || ""}
+                onChange={(e) => handleInputChange("doi", e.target.value)}
                 placeholder="10.xxxx/xxxxx"
               />
             </div>
@@ -425,8 +481,8 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               <Input
                 id="url"
                 type="url"
-                value={formData.url || ''}
-                onChange={(e) => handleInputChange('url', e.target.value)}
+                value={formData.url || ""}
+                onChange={(e) => handleInputChange("url", e.target.value)}
               />
             </div>
           </div>
@@ -439,8 +495,8 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               <Label htmlFor="notes">Notes</Label>
               <Textarea
                 id="notes"
-                value={formData.notes || ''}
-                onChange={(e) => handleInputChange('notes', e.target.value)}
+                value={formData.notes || ""}
+                onChange={(e) => handleInputChange("notes", e.target.value)}
                 rows={3}
               />
             </div>
@@ -452,7 +508,9 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   value={tagInput}
                   onChange={(e) => setTagInput(e.target.value)}
                   placeholder="Add tag"
-                  onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
+                  onKeyPress={(e) =>
+                    e.key === "Enter" && (e.preventDefault(), addTag())
+                  }
                 />
                 <Button type="button" onClick={addTag} size="sm">
                   <Plus className="h-4 w-4" />
@@ -460,7 +518,11 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               </div>
               <div className="flex flex-wrap gap-2">
                 {(formData.tags || []).map((tag, index) => (
-                  <Badge key={index} variant="secondary" className="flex items-center gap-1">
+                  <Badge
+                    key={index}
+                    variant="secondary"
+                    className="flex items-center gap-1"
+                  >
                     {tag}
                     <button
                       type="button"
@@ -481,11 +543,15 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
               Cancel
             </Button>
             <Button type="submit" disabled={!isFormValid || loading}>
-              {loading ? 'Saving...' : isEditing ? 'Update Reference' : 'Add Reference'}
+              {loading
+                ? "Saving..."
+                : isEditing
+                  ? "Update Reference"
+                  : "Add Reference"}
             </Button>
           </div>
         </form>
       </CardContent>
     </Card>
-  )
-}
+  );
+};

--- a/src/components/ui/search-result-export.tsx
+++ b/src/components/ui/search-result-export.tsx
@@ -1,145 +1,160 @@
-"use client"
+"use client";
 
-import React, { useState } from "react"
-import { Button } from "./shadcn/button"
-import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./shadcn/select"
-import { Checkbox } from "./shadcn/checkbox"
-import { Label } from "./shadcn/label"
-import { Textarea } from "./shadcn/textarea"
-import { 
-  Download, 
-  FileText, 
-  FileSpreadsheet, 
-  Code, 
+import React, { useState } from "react";
+import { Button } from "./shadcn/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./shadcn/select";
+import { Checkbox } from "./shadcn/checkbox";
+import { Label } from "./shadcn/label";
+import { Textarea } from "./shadcn/textarea";
+import {
+  Download,
+  FileText,
+  FileSpreadsheet,
+  Code,
   Share2,
   Copy,
   Check,
-  X
-} from "lucide-react"
-import { ScholarSearchResult, CitationStyle } from "../../lib/ai-types"
+  X,
+} from "lucide-react";
+import { ScholarSearchResult, CitationStyle } from "../../lib/ai-types";
 
-export type ExportFormat = 'json' | 'csv' | 'bibtex' | 'ris' | 'txt' | 'markdown'
+export type ExportFormat =
+  | "json"
+  | "csv"
+  | "bibtex"
+  | "ris"
+  | "txt"
+  | "markdown";
 
 export interface ExportOptions {
-  format: ExportFormat
-  includeScores: boolean
-  includeAbstracts: boolean
-  includeUrls: boolean
-  includeDoi: boolean
-  includeKeywords: boolean
-  citationStyle?: CitationStyle
-  customFields?: string[]
-  filename?: string
+  format: ExportFormat;
+  includeScores: boolean;
+  includeAbstracts: boolean;
+  includeUrls: boolean;
+  includeDoi: boolean;
+  includeKeywords: boolean;
+  citationStyle?: CitationStyle;
+  customFields?: string[];
+  filename?: string;
 }
 
 interface SearchResultExportProps {
-  results: ScholarSearchResult[]
-  onExport: (results: ScholarSearchResult[], options: ExportOptions) => Promise<string>
-  onClose?: () => void
-  className?: string
+  results: ScholarSearchResult[];
+  onExport: (
+    results: ScholarSearchResult[],
+    options: ExportOptions,
+  ) => Promise<string>;
+  onClose?: () => void;
+  className?: string;
 }
 
 export const SearchResultExport: React.FC<SearchResultExportProps> = ({
   results,
   onExport,
   onClose,
-  className = ""
+  className = "",
 }) => {
   const [exportOptions, setExportOptions] = useState<ExportOptions>({
-    format: 'json',
+    format: "json",
     includeScores: true,
     includeAbstracts: true,
     includeUrls: true,
     includeDoi: true,
     includeKeywords: true,
     citationStyle: CitationStyle.APA,
-    filename: `search-results-${new Date().toISOString().split('T')[0]}`
-  })
-  
-  const [isExporting, setIsExporting] = useState(false)
-  const [exportedContent, setExportedContent] = useState<string | null>(null)
-  const [copied, setCopied] = useState(false)
+    filename: `search-results-${new Date().toISOString().split("T")[0]}`,
+  });
+
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportedContent, setExportedContent] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const handleExport = async () => {
-    setIsExporting(true)
+    setIsExporting(true);
     try {
-      const content = await onExport(results, exportOptions)
-      setExportedContent(content)
+      const content = await onExport(results, exportOptions);
+      setExportedContent(content);
     } catch (error) {
-      console.error('Export failed:', error)
+      console.error("Export failed:", error);
     } finally {
-      setIsExporting(false)
+      setIsExporting(false);
     }
-  }
+  };
 
   const handleDownload = () => {
-    if (!exportedContent) return
+    if (!exportedContent) return;
 
-    const blob = new Blob([exportedContent], { 
-      type: getContentType(exportOptions.format) 
-    })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${exportOptions.filename}.${exportOptions.format}`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  }
+    const blob = new Blob([exportedContent], {
+      type: getContentType(exportOptions.format),
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${exportOptions.filename}.${exportOptions.format}`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
 
   const handleCopyToClipboard = async () => {
-    if (!exportedContent) return
+    if (!exportedContent) return;
 
     try {
-      await navigator.clipboard.writeText(exportedContent)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      await navigator.clipboard.writeText(exportedContent);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     } catch (error) {
-      console.error('Failed to copy to clipboard:', error)
+      console.error("Failed to copy to clipboard:", error);
     }
-  }
+  };
 
   const getContentType = (format: ExportFormat): string => {
     switch (format) {
-      case 'json':
-        return 'application/json'
-      case 'csv':
-        return 'text/csv'
-      case 'bibtex':
-        return 'application/x-bibtex'
-      case 'ris':
-        return 'application/x-research-info-systems'
-      case 'txt':
-        return 'text/plain'
-      case 'markdown':
-        return 'text/markdown'
+      case "json":
+        return "application/json";
+      case "csv":
+        return "text/csv";
+      case "bibtex":
+        return "application/x-bibtex";
+      case "ris":
+        return "application/x-research-info-systems";
+      case "txt":
+        return "text/plain";
+      case "markdown":
+        return "text/markdown";
       default:
-        return 'text/plain'
+        return "text/plain";
     }
-  }
+  };
 
   const getFormatIcon = (format: ExportFormat) => {
     switch (format) {
-      case 'json':
-      case 'bibtex':
-      case 'ris':
-        return <Code className="h-4 w-4" />
-      case 'csv':
-        return <FileSpreadsheet className="h-4 w-4" />
-      case 'txt':
-      case 'markdown':
-        return <FileText className="h-4 w-4" />
+      case "json":
+      case "bibtex":
+      case "ris":
+        return <Code className="h-4 w-4" />;
+      case "csv":
+        return <FileSpreadsheet className="h-4 w-4" />;
+      case "txt":
+      case "markdown":
+        return <FileText className="h-4 w-4" />;
       default:
-        return <FileText className="h-4 w-4" />
+        return <FileText className="h-4 w-4" />;
     }
-  }
+  };
 
   const updateExportOptions = (updates: Partial<ExportOptions>) => {
-    setExportOptions(prev => ({ ...prev, ...updates }))
-    setExportedContent(null) // Clear previous export when options change
-  }
+    setExportOptions((prev) => ({ ...prev, ...updates }));
+    setExportedContent(null); // Clear previous export when options change
+  };
 
   return (
     <div className={`space-y-4 ${className}`}>
@@ -151,20 +166,27 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
               Export Search Results ({results.length} results)
             </CardTitle>
             {onClose && (
-              <Button variant="ghost" size="sm" onClick={onClose}>
+              <Button
+                aria-label="Close"
+                variant="ghost"
+                size="sm"
+                onClick={onClose}
+              >
                 <X className="h-4 w-4" />
               </Button>
             )}
           </div>
         </CardHeader>
-        
+
         <CardContent className="space-y-4">
           {/* Format Selection */}
           <div className="space-y-2">
             <Label>Export Format</Label>
-            <Select 
-              value={exportOptions.format} 
-              onValueChange={(value) => updateExportOptions({ format: value as ExportFormat })}
+            <Select
+              value={exportOptions.format}
+              onValueChange={(value) =>
+                updateExportOptions({ format: value as ExportFormat })
+              }
             >
               <SelectTrigger>
                 <SelectValue />
@@ -211,12 +233,16 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
           </div>
 
           {/* Citation Style (for BibTeX, RIS, and text formats) */}
-          {(['bibtex', 'ris', 'txt', 'markdown'].includes(exportOptions.format)) && (
+          {["bibtex", "ris", "txt", "markdown"].includes(
+            exportOptions.format,
+          ) && (
             <div className="space-y-2">
               <Label>Citation Style</Label>
-              <Select 
-                value={exportOptions.citationStyle} 
-                onValueChange={(value) => updateExportOptions({ citationStyle: value as CitationStyle })}
+              <Select
+                value={exportOptions.citationStyle}
+                onValueChange={(value) =>
+                  updateExportOptions({ citationStyle: value as CitationStyle })
+                }
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -227,7 +253,9 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
                   <SelectItem value={CitationStyle.CHICAGO}>Chicago</SelectItem>
                   <SelectItem value={CitationStyle.HARVARD}>Harvard</SelectItem>
                   <SelectItem value={CitationStyle.IEEE}>IEEE</SelectItem>
-                  <SelectItem value={CitationStyle.VANCOUVER}>Vancouver</SelectItem>
+                  <SelectItem value={CitationStyle.VANCOUVER}>
+                    Vancouver
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -241,45 +269,65 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
                 <Checkbox
                   id="include-scores"
                   checked={exportOptions.includeScores}
-                  onCheckedChange={(checked) => updateExportOptions({ includeScores: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateExportOptions({ includeScores: !!checked })
+                  }
                 />
-                <Label htmlFor="include-scores" className="text-sm">Relevance scores</Label>
+                <Label htmlFor="include-scores" className="text-sm">
+                  Relevance scores
+                </Label>
               </div>
-              
+
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="include-abstracts"
                   checked={exportOptions.includeAbstracts}
-                  onCheckedChange={(checked) => updateExportOptions({ includeAbstracts: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateExportOptions({ includeAbstracts: !!checked })
+                  }
                 />
-                <Label htmlFor="include-abstracts" className="text-sm">Abstracts</Label>
+                <Label htmlFor="include-abstracts" className="text-sm">
+                  Abstracts
+                </Label>
               </div>
-              
+
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="include-urls"
                   checked={exportOptions.includeUrls}
-                  onCheckedChange={(checked) => updateExportOptions({ includeUrls: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateExportOptions({ includeUrls: !!checked })
+                  }
                 />
-                <Label htmlFor="include-urls" className="text-sm">URLs</Label>
+                <Label htmlFor="include-urls" className="text-sm">
+                  URLs
+                </Label>
               </div>
-              
+
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="include-doi"
                   checked={exportOptions.includeDoi}
-                  onCheckedChange={(checked) => updateExportOptions({ includeDoi: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateExportOptions({ includeDoi: !!checked })
+                  }
                 />
-                <Label htmlFor="include-doi" className="text-sm">DOI</Label>
+                <Label htmlFor="include-doi" className="text-sm">
+                  DOI
+                </Label>
               </div>
-              
+
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="include-keywords"
                   checked={exportOptions.includeKeywords}
-                  onCheckedChange={(checked) => updateExportOptions({ includeKeywords: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateExportOptions({ includeKeywords: !!checked })
+                  }
                 />
-                <Label htmlFor="include-keywords" className="text-sm">Keywords</Label>
+                <Label htmlFor="include-keywords" className="text-sm">
+                  Keywords
+                </Label>
               </div>
             </div>
           </div>
@@ -290,8 +338,10 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
             <input
               id="filename"
               type="text"
-              value={exportOptions.filename || ''}
-              onChange={(e) => updateExportOptions({ filename: e.target.value })}
+              value={exportOptions.filename || ""}
+              onChange={(e) =>
+                updateExportOptions({ filename: e.target.value })
+              }
               className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
               placeholder="search-results"
             />
@@ -304,7 +354,9 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
             className="w-full flex items-center gap-2"
           >
             {getFormatIcon(exportOptions.format)}
-            {isExporting ? 'Generating Export...' : `Generate ${exportOptions.format.toUpperCase()} Export`}
+            {isExporting
+              ? "Generating Export..."
+              : `Generate ${exportOptions.format.toUpperCase()} Export`}
           </Button>
         </CardContent>
       </Card>
@@ -319,7 +371,10 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
             {/* Preview */}
             <div className="max-h-64 overflow-y-auto">
               <Textarea
-                value={exportedContent.substring(0, 1000) + (exportedContent.length > 1000 ? '\n\n... (truncated)' : '')}
+                value={
+                  exportedContent.substring(0, 1000) +
+                  (exportedContent.length > 1000 ? "\n\n... (truncated)" : "")
+                }
                 readOnly
                 className="min-h-32 font-mono text-xs"
               />
@@ -334,7 +389,7 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
                 <Download className="h-4 w-4" />
                 Download File
               </Button>
-              
+
               <Button
                 variant="outline"
                 onClick={handleCopyToClipboard}
@@ -355,11 +410,12 @@ export const SearchResultExport: React.FC<SearchResultExportProps> = ({
             </div>
 
             <div className="text-xs text-muted-foreground">
-              Export contains {results.length} results ({exportedContent.length.toLocaleString()} characters)
+              Export contains {results.length} results (
+              {exportedContent.length.toLocaleString()} characters)
             </div>
           </CardContent>
         </Card>
       )}
     </div>
-  )
-}
+  );
+};

--- a/src/components/ui/search-result-feedback.tsx
+++ b/src/components/ui/search-result-feedback.tsx
@@ -1,100 +1,96 @@
-"use client"
+"use client";
 
-import React, { useState } from "react"
-import { Button } from "./shadcn/button"
-import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card"
-import { Badge } from "./shadcn/badge"
-import { Textarea } from "./shadcn/textarea"
-import { Label } from "./shadcn/label"
-import { 
-  ThumbsUp, 
-  ThumbsDown, 
-  Star, 
-  MessageSquare, 
+import React, { useState } from "react";
+import { Button } from "./shadcn/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card";
+import { Badge } from "./shadcn/badge";
+import { Textarea } from "./shadcn/textarea";
+import { Label } from "./shadcn/label";
+import {
+  ThumbsUp,
+  ThumbsDown,
+  Star,
+  MessageSquare,
   X,
   Send,
-  AlertCircle
-} from "lucide-react"
+  AlertCircle,
+} from "lucide-react";
 
 export interface SearchResultFeedback {
-  resultId: string
-  isRelevant: boolean
-  qualityRating: number // 1-5 scale
-  comments?: string
-  timestamp: Date
+  resultId: string;
+  isRelevant: boolean;
+  qualityRating: number; // 1-5 scale
+  comments?: string;
+  timestamp: Date;
 }
 
 export interface SearchResultFeedbackProps {
-  resultId: string
-  resultTitle: string
-  onSubmitFeedback: (feedback: SearchResultFeedback) => Promise<void>
-  onCancel?: () => void
-  className?: string
+  resultId: string;
+  resultTitle: string;
+  onSubmitFeedback: (feedback: SearchResultFeedback) => Promise<void>;
+  onCancel?: () => void;
+  className?: string;
 }
 
-export const SearchResultFeedbackComponent: React.FC<SearchResultFeedbackProps> = ({
-  resultId,
-  resultTitle,
-  onSubmitFeedback,
-  onCancel,
-  className = ""
-}) => {
-  const [isRelevant, setIsRelevant] = useState<boolean | null>(null)
-  const [qualityRating, setQualityRating] = useState<number>(0)
-  const [comments, setComments] = useState("")
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [showDetailedForm, setShowDetailedForm] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+export const SearchResultFeedbackComponent: React.FC<
+  SearchResultFeedbackProps
+> = ({ resultId, resultTitle, onSubmitFeedback, onCancel, className = "" }) => {
+  const [isRelevant, setIsRelevant] = useState<boolean | null>(null);
+  const [qualityRating, setQualityRating] = useState<number>(0);
+  const [comments, setComments] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showDetailedForm, setShowDetailedForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleRelevanceClick = (relevant: boolean) => {
-    setIsRelevant(relevant)
-    setError(null)
-    
+    setIsRelevant(relevant);
+    setError(null);
+
     // If marking as not relevant, show detailed form for feedback
     if (!relevant) {
-      setShowDetailedForm(true)
+      setShowDetailedForm(true);
     }
-  }
+  };
 
   const handleStarClick = (rating: number) => {
-    setQualityRating(rating)
-    setError(null)
-  }
+    setQualityRating(rating);
+    setError(null);
+  };
 
   const handleQuickFeedback = async (relevant: boolean, rating: number = 3) => {
-    if (isSubmitting) return
+    if (isSubmitting) return;
 
-    setIsSubmitting(true)
-    setError(null)
+    setIsSubmitting(true);
+    setError(null);
 
     try {
       const feedback: SearchResultFeedback = {
         resultId,
         isRelevant: relevant,
         qualityRating: rating,
-        timestamp: new Date()
-      }
+        timestamp: new Date(),
+      };
 
-      await onSubmitFeedback(feedback)
+      await onSubmitFeedback(feedback);
     } catch (error) {
-      console.error('Error submitting quick feedback:', error)
-      setError('Failed to submit feedback. Please try again.')
+      console.error("Error submitting quick feedback:", error);
+      setError("Failed to submit feedback. Please try again.");
     } finally {
-      setIsSubmitting(false)
+      setIsSubmitting(false);
     }
-  }
+  };
 
   const handleDetailedSubmit = async () => {
-    if (isSubmitting || isRelevant === null) return
+    if (isSubmitting || isRelevant === null) return;
 
     // Validate required fields
     if (!isRelevant && qualityRating === 0) {
-      setError('Please provide a quality rating')
-      return
+      setError("Please provide a quality rating");
+      return;
     }
 
-    setIsSubmitting(true)
-    setError(null)
+    setIsSubmitting(true);
+    setError(null);
 
     try {
       const feedback: SearchResultFeedback = {
@@ -102,26 +98,26 @@ export const SearchResultFeedbackComponent: React.FC<SearchResultFeedbackProps> 
         isRelevant,
         qualityRating: qualityRating || 3,
         comments: comments.trim() || undefined,
-        timestamp: new Date()
-      }
+        timestamp: new Date(),
+      };
 
-      await onSubmitFeedback(feedback)
+      await onSubmitFeedback(feedback);
     } catch (error) {
-      console.error('Error submitting detailed feedback:', error)
-      setError('Failed to submit feedback. Please try again.')
+      console.error("Error submitting detailed feedback:", error);
+      setError("Failed to submit feedback. Please try again.");
     } finally {
-      setIsSubmitting(false)
+      setIsSubmitting(false);
     }
-  }
+  };
 
   const handleCancel = () => {
-    setIsRelevant(null)
-    setQualityRating(0)
-    setComments("")
-    setShowDetailedForm(false)
-    setError(null)
-    onCancel?.()
-  }
+    setIsRelevant(null);
+    setQualityRating(0);
+    setComments("");
+    setShowDetailedForm(false);
+    setError(null);
+    onCancel?.();
+  };
 
   const renderStarRating = (interactive: boolean = true) => {
     return (
@@ -133,17 +129,17 @@ export const SearchResultFeedbackComponent: React.FC<SearchResultFeedbackProps> 
             onClick={() => interactive && handleStarClick(star)}
             disabled={!interactive || isSubmitting}
             className={`p-1 rounded transition-colors ${
-              interactive && !isSubmitting 
-                ? 'hover:bg-gray-100 cursor-pointer' 
-                : 'cursor-default'
+              interactive && !isSubmitting
+                ? "hover:bg-gray-100 cursor-pointer"
+                : "cursor-default"
             }`}
             aria-label={`Rate ${star} out of 5 stars`}
           >
             <Star
               className={`h-4 w-4 ${
                 star <= qualityRating
-                  ? 'fill-yellow-400 text-yellow-400'
-                  : 'text-gray-300'
+                  ? "fill-yellow-400 text-yellow-400"
+                  : "text-gray-300"
               }`}
             />
           </button>
@@ -154,8 +150,8 @@ export const SearchResultFeedbackComponent: React.FC<SearchResultFeedbackProps> 
           </span>
         )}
       </div>
-    )
-  }
+    );
+  };
 
   // Quick feedback buttons (shown initially)
   if (!showDetailedForm && isRelevant === null) {
@@ -166,6 +162,7 @@ export const SearchResultFeedbackComponent: React.FC<SearchResultFeedbackProps> 
             Was this result helpful?
           </span>
           <Button
+            aria-label="Close"
             variant="ghost"
             size="sm"
             onClick={handleCancel}
@@ -215,7 +212,7 @@ export const SearchResultFeedbackComponent: React.FC<SearchResultFeedbackProps> 
           </div>
         )}
       </div>
-    )
+    );
   }
 
   // Detailed feedback form
@@ -224,12 +221,13 @@ export const SearchResultFeedbackComponent: React.FC<SearchResultFeedbackProps> 
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-sm font-medium">
-            Feedback for: {resultTitle.length > 50 
-              ? `${resultTitle.substring(0, 50)}...` 
-              : resultTitle
-            }
+            Feedback for:{" "}
+            {resultTitle.length > 50
+              ? `${resultTitle.substring(0, 50)}...`
+              : resultTitle}
           </CardTitle>
           <Button
+            aria-label="Close"
             variant="ghost"
             size="sm"
             onClick={handleCancel}
@@ -325,42 +323,45 @@ export const SearchResultFeedbackComponent: React.FC<SearchResultFeedbackProps> 
             className="flex items-center gap-2"
           >
             <Send className="h-4 w-4" />
-            {isSubmitting ? 'Submitting...' : 'Submit Feedback'}
+            {isSubmitting ? "Submitting..." : "Submit Feedback"}
           </Button>
         </div>
       </CardContent>
     </Card>
-  )
-}
+  );
+};
 
 // Quick feedback buttons component for inline use
 export interface QuickFeedbackButtonsProps {
-  resultId: string
-  onFeedback: (feedback: { isRelevant: boolean; rating: number }) => Promise<void>
-  disabled?: boolean
-  className?: string
+  resultId: string;
+  onFeedback: (feedback: {
+    isRelevant: boolean;
+    rating: number;
+  }) => Promise<void>;
+  disabled?: boolean;
+  className?: string;
 }
 
 export const QuickFeedbackButtons: React.FC<QuickFeedbackButtonsProps> = ({
   resultId,
   onFeedback,
   disabled = false,
-  className = ""
+  className = "",
 }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleQuickFeedback = async (isRelevant: boolean, rating: number) => {
-    if (isSubmitting || disabled) return
+    if (isSubmitting || disabled) return;
 
-    setIsSubmitting(true)
+    setIsSubmitting(true);
     try {
-      await onFeedback({ isRelevant, rating })
+      await onFeedback({ isRelevant, rating });
     } catch (error) {
-      console.error('Error submitting quick feedback:', error)
+      console.error("Error submitting quick feedback:", error);
     } finally {
-      setIsSubmitting(false)
+      setIsSubmitting(false);
     }
-  }
+  };
 
   return (
     <div className={`flex items-center gap-1 ${className}`}>
@@ -385,5 +386,5 @@ export const QuickFeedbackButtons: React.FC<QuickFeedbackButtonsProps> = ({
         <ThumbsDown className="h-3 w-3" />
       </Button>
     </div>
-  )
-}
+  );
+};

--- a/src/components/ui/search-result-management-panel.tsx
+++ b/src/components/ui/search-result-management-panel.tsx
@@ -1,203 +1,239 @@
-"use client"
+"use client";
 
-import React, { useState, useEffect } from "react"
-import { Button } from "./shadcn/button"
-import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./shadcn/tabs"
-import { Badge } from "./shadcn/badge"
-import { 
-  Bookmark, 
-  Compare, 
-  Download, 
-  Share2, 
+import React, { useState, useEffect } from "react";
+import { Button } from "./shadcn/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./shadcn/tabs";
+import { Badge } from "./shadcn/badge";
+import {
+  Bookmark,
+  Compare,
+  Download,
+  Share2,
   Settings,
   X,
-  RefreshCw
-} from "lucide-react"
-import { ScholarSearchResult } from "../../lib/ai-types"
-import { BookmarkedResultsList, BookmarkedResult } from "./search-result-bookmark"
-import { SearchResultComparison, ComparisonResult } from "./search-result-comparison"
-import { SearchResultExport, ExportOptions } from "./search-result-export"
-import { SearchResultSharing, ShareOptions, SharedResult } from "./search-result-sharing"
+  RefreshCw,
+} from "lucide-react";
+import { ScholarSearchResult } from "../../lib/ai-types";
+import {
+  BookmarkedResultsList,
+  BookmarkedResult,
+} from "./search-result-bookmark";
+import {
+  SearchResultComparison,
+  ComparisonResult,
+} from "./search-result-comparison";
+import { SearchResultExport, ExportOptions } from "./search-result-export";
+import {
+  SearchResultSharing,
+  ShareOptions,
+  SharedResult,
+} from "./search-result-sharing";
 
 interface SearchResultManagementPanelProps {
-  userId: string
-  onAddReference?: (result: ScholarSearchResult) => Promise<void>
-  onClose?: () => void
-  className?: string
+  userId: string;
+  onAddReference?: (result: ScholarSearchResult) => Promise<void>;
+  onClose?: () => void;
+  className?: string;
 }
 
-export const SearchResultManagementPanel: React.FC<SearchResultManagementPanelProps> = ({
-  userId,
-  onAddReference,
-  onClose,
-  className = ""
-}) => {
-  const [activeTab, setActiveTab] = useState<'bookmarks' | 'comparison' | 'export' | 'sharing'>('bookmarks')
-  const [bookmarkedResults, setBookmarkedResults] = useState<BookmarkedResult[]>([])
-  const [comparisonResults, setComparisonResults] = useState<ComparisonResult[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+export const SearchResultManagementPanel: React.FC<
+  SearchResultManagementPanelProps
+> = ({ userId, onAddReference, onClose, className = "" }) => {
+  const [activeTab, setActiveTab] = useState<
+    "bookmarks" | "comparison" | "export" | "sharing"
+  >("bookmarks");
+  const [bookmarkedResults, setBookmarkedResults] = useState<
+    BookmarkedResult[]
+  >([]);
+  const [comparisonResults, setComparisonResults] = useState<
+    ComparisonResult[]
+  >([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // Load data on mount and when userId changes
   useEffect(() => {
     if (userId) {
-      loadBookmarkedResults()
-      loadComparisonResults()
+      loadBookmarkedResults();
+      loadComparisonResults();
     }
-  }, [userId])
+  }, [userId]);
 
   const loadBookmarkedResults = async () => {
-    setLoading(true)
+    setLoading(true);
     try {
-      const response = await fetch(`/api/search-result-management/bookmarks/${userId}`)
-      const data = await response.json()
-      
+      const response = await fetch(
+        `/api/search-result-management/bookmarks/${userId}`,
+      );
+      const data = await response.json();
+
       if (data.success) {
-        setBookmarkedResults(data.bookmarks || [])
+        setBookmarkedResults(data.bookmarks || []);
       } else {
-        throw new Error(data.error || 'Failed to load bookmarks')
+        throw new Error(data.error || "Failed to load bookmarks");
       }
     } catch (error) {
-      console.error('Error loading bookmarks:', error)
-      setError(error instanceof Error ? error.message : 'Failed to load bookmarks')
+      console.error("Error loading bookmarks:", error);
+      setError(
+        error instanceof Error ? error.message : "Failed to load bookmarks",
+      );
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   const loadComparisonResults = async () => {
     try {
-      const response = await fetch(`/api/search-result-management/comparison/${userId}`)
-      const data = await response.json()
-      
+      const response = await fetch(
+        `/api/search-result-management/comparison/${userId}`,
+      );
+      const data = await response.json();
+
       if (data.success) {
-        setComparisonResults(data.comparisons || [])
+        setComparisonResults(data.comparisons || []);
       } else {
-        throw new Error(data.error || 'Failed to load comparison results')
+        throw new Error(data.error || "Failed to load comparison results");
       }
     } catch (error) {
-      console.error('Error loading comparison results:', error)
-      setError(error instanceof Error ? error.message : 'Failed to load comparison results')
+      console.error("Error loading comparison results:", error);
+      setError(
+        error instanceof Error
+          ? error.message
+          : "Failed to load comparison results",
+      );
     }
-  }
+  };
 
   const handleRemoveBookmark = async (result: BookmarkedResult) => {
     try {
-      const response = await fetch('/api/search-result-management/bookmarks', {
-        method: 'DELETE',
+      const response = await fetch("/api/search-result-management/bookmarks", {
+        method: "DELETE",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           result,
-          userId
-        })
-      })
+          userId,
+        }),
+      });
 
-      const data = await response.json()
-      
+      const data = await response.json();
+
       if (data.success) {
-        setBookmarkedResults(prev => prev.filter(b => b.bookmarkId !== result.bookmarkId))
+        setBookmarkedResults((prev) =>
+          prev.filter((b) => b.bookmarkId !== result.bookmarkId),
+        );
       } else {
-        throw new Error(data.error || 'Failed to remove bookmark')
+        throw new Error(data.error || "Failed to remove bookmark");
       }
     } catch (error) {
-      console.error('Error removing bookmark:', error)
-      throw error
+      console.error("Error removing bookmark:", error);
+      throw error;
     }
-  }
+  };
 
   const handleRemoveFromComparison = (result: ComparisonResult) => {
-    setComparisonResults(prev => prev.filter(c => c.comparisonId !== result.comparisonId))
-  }
+    setComparisonResults((prev) =>
+      prev.filter((c) => c.comparisonId !== result.comparisonId),
+    );
+  };
 
   const handleClearComparison = async () => {
     try {
-      const response = await fetch(`/api/search-result-management/comparison/${userId}`, {
-        method: 'DELETE'
-      })
-
-      const data = await response.json()
-      
-      if (data.success) {
-        setComparisonResults([])
-      } else {
-        throw new Error(data.error || 'Failed to clear comparison')
-      }
-    } catch (error) {
-      console.error('Error clearing comparison:', error)
-    }
-  }
-
-  const handleExportResults = async (results: ScholarSearchResult[], options: ExportOptions): Promise<string> => {
-    try {
-      const response = await fetch('/api/search-result-management/export', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const response = await fetch(
+        `/api/search-result-management/comparison/${userId}`,
+        {
+          method: "DELETE",
         },
-        body: JSON.stringify({
-          results,
-          options
-        })
-      })
+      );
 
-      const data = await response.json()
-      
+      const data = await response.json();
+
       if (data.success) {
-        return data.content
+        setComparisonResults([]);
       } else {
-        throw new Error(data.error || 'Export failed')
+        throw new Error(data.error || "Failed to clear comparison");
       }
     } catch (error) {
-      console.error('Error exporting results:', error)
-      throw error
+      console.error("Error clearing comparison:", error);
     }
-  }
+  };
 
-  const handleShareResults = async (results: ScholarSearchResult[], options: ShareOptions): Promise<SharedResult> => {
+  const handleExportResults = async (
+    results: ScholarSearchResult[],
+    options: ExportOptions,
+  ): Promise<string> => {
     try {
-      const response = await fetch('/api/search-result-management/share', {
-        method: 'POST',
+      const response = await fetch("/api/search-result-management/export", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           results,
           options,
-          userId
-        })
-      })
+        }),
+      });
 
-      const data = await response.json()
-      
+      const data = await response.json();
+
       if (data.success) {
-        return data.sharedResult
+        return data.content;
       } else {
-        throw new Error(data.error || 'Sharing failed')
+        throw new Error(data.error || "Export failed");
       }
     } catch (error) {
-      console.error('Error sharing results:', error)
-      throw error
+      console.error("Error exporting results:", error);
+      throw error;
     }
-  }
+  };
+
+  const handleShareResults = async (
+    results: ScholarSearchResult[],
+    options: ShareOptions,
+  ): Promise<SharedResult> => {
+    try {
+      const response = await fetch("/api/search-result-management/share", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          results,
+          options,
+          userId,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (data.success) {
+        return data.sharedResult;
+      } else {
+        throw new Error(data.error || "Sharing failed");
+      }
+    } catch (error) {
+      console.error("Error sharing results:", error);
+      throw error;
+    }
+  };
 
   const handleRefresh = () => {
-    loadBookmarkedResults()
-    loadComparisonResults()
-  }
+    loadBookmarkedResults();
+    loadComparisonResults();
+  };
 
   const getTabCount = (tab: string): number => {
     switch (tab) {
-      case 'bookmarks':
-        return bookmarkedResults.length
-      case 'comparison':
-        return comparisonResults.length
+      case "bookmarks":
+        return bookmarkedResults.length;
+      case "comparison":
+        return comparisonResults.length;
       default:
-        return 0
+        return 0;
     }
-  }
+  };
 
   return (
     <div className={`space-y-4 ${className}`}>
@@ -216,36 +252,52 @@ export const SearchResultManagementPanel: React.FC<SearchResultManagementPanelPr
                 disabled={loading}
                 className="flex items-center gap-2"
               >
-                <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+                <RefreshCw
+                  className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+                />
                 Refresh
               </Button>
               {onClose && (
-                <Button variant="ghost" size="sm" onClick={onClose}>
+                <Button
+                  aria-label="Close"
+                  variant="ghost"
+                  size="sm"
+                  onClick={onClose}
+                >
                   <X className="h-4 w-4" />
                 </Button>
               )}
             </div>
           </div>
         </CardHeader>
-        
+
         <CardContent>
-          <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as any)}>
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => setActiveTab(value as any)}
+          >
             <TabsList className="grid w-full grid-cols-4">
-              <TabsTrigger value="bookmarks" className="flex items-center gap-2">
+              <TabsTrigger
+                value="bookmarks"
+                className="flex items-center gap-2"
+              >
                 <Bookmark className="h-4 w-4" />
                 Bookmarks
-                {getTabCount('bookmarks') > 0 && (
+                {getTabCount("bookmarks") > 0 && (
                   <Badge variant="secondary" className="ml-1">
-                    {getTabCount('bookmarks')}
+                    {getTabCount("bookmarks")}
                   </Badge>
                 )}
               </TabsTrigger>
-              <TabsTrigger value="comparison" className="flex items-center gap-2">
+              <TabsTrigger
+                value="comparison"
+                className="flex items-center gap-2"
+              >
                 <Compare className="h-4 w-4" />
                 Compare
-                {getTabCount('comparison') > 0 && (
+                {getTabCount("comparison") > 0 && (
                   <Badge variant="secondary" className="ml-1">
-                    {getTabCount('comparison')}
+                    {getTabCount("comparison")}
                   </Badge>
                 )}
               </TabsTrigger>
@@ -284,21 +336,26 @@ export const SearchResultManagementPanel: React.FC<SearchResultManagementPanelPr
               </TabsContent>
 
               <TabsContent value="export" className="space-y-4">
-                {bookmarkedResults.length > 0 || comparisonResults.length > 0 ? (
+                {bookmarkedResults.length > 0 ||
+                comparisonResults.length > 0 ? (
                   <div className="space-y-4">
                     {bookmarkedResults.length > 0 && (
                       <div>
-                        <h5 className="font-medium mb-2">Export Bookmarked Results</h5>
+                        <h5 className="font-medium mb-2">
+                          Export Bookmarked Results
+                        </h5>
                         <SearchResultExport
                           results={bookmarkedResults}
                           onExport={handleExportResults}
                         />
                       </div>
                     )}
-                    
+
                     {comparisonResults.length > 0 && (
                       <div>
-                        <h5 className="font-medium mb-2">Export Comparison Results</h5>
+                        <h5 className="font-medium mb-2">
+                          Export Comparison Results
+                        </h5>
                         <SearchResultExport
                           results={comparisonResults}
                           onExport={handleExportResults}
@@ -310,27 +367,34 @@ export const SearchResultManagementPanel: React.FC<SearchResultManagementPanelPr
                   <div className="text-center py-8 text-muted-foreground">
                     <Download className="h-12 w-12 mx-auto mb-4 opacity-50" />
                     <p>No results to export</p>
-                    <p className="text-sm">Bookmark or add results to comparison first.</p>
+                    <p className="text-sm">
+                      Bookmark or add results to comparison first.
+                    </p>
                   </div>
                 )}
               </TabsContent>
 
               <TabsContent value="sharing" className="space-y-4">
-                {bookmarkedResults.length > 0 || comparisonResults.length > 0 ? (
+                {bookmarkedResults.length > 0 ||
+                comparisonResults.length > 0 ? (
                   <div className="space-y-4">
                     {bookmarkedResults.length > 0 && (
                       <div>
-                        <h5 className="font-medium mb-2">Share Bookmarked Results</h5>
+                        <h5 className="font-medium mb-2">
+                          Share Bookmarked Results
+                        </h5>
                         <SearchResultSharing
                           results={bookmarkedResults}
                           onShare={handleShareResults}
                         />
                       </div>
                     )}
-                    
+
                     {comparisonResults.length > 0 && (
                       <div>
-                        <h5 className="font-medium mb-2">Share Comparison Results</h5>
+                        <h5 className="font-medium mb-2">
+                          Share Comparison Results
+                        </h5>
                         <SearchResultSharing
                           results={comparisonResults}
                           onShare={handleShareResults}
@@ -342,7 +406,9 @@ export const SearchResultManagementPanel: React.FC<SearchResultManagementPanelPr
                   <div className="text-center py-8 text-muted-foreground">
                     <Share2 className="h-12 w-12 mx-auto mb-4 opacity-50" />
                     <p>No results to share</p>
-                    <p className="text-sm">Bookmark or add results to comparison first.</p>
+                    <p className="text-sm">
+                      Bookmark or add results to comparison first.
+                    </p>
                   </div>
                 )}
               </TabsContent>
@@ -351,5 +417,5 @@ export const SearchResultManagementPanel: React.FC<SearchResultManagementPanelPr
         </CardContent>
       </Card>
     </div>
-  )
-}
+  );
+};

--- a/src/components/ui/search-result-sharing.tsx
+++ b/src/components/ui/search-result-sharing.tsx
@@ -1,143 +1,158 @@
-"use client"
+"use client";
 
-import React, { useState } from "react"
-import { Button } from "./shadcn/button"
-import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card"
-import { Input } from "./shadcn/input"
-import { Label } from "./shadcn/label"
-import { Textarea } from "./shadcn/textarea"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./shadcn/select"
-import { Checkbox } from "./shadcn/checkbox"
-import { Badge } from "./shadcn/badge"
-import { 
-  Share2, 
-  Copy, 
-  Check, 
-  Mail, 
-  Link, 
+import React, { useState } from "react";
+import { Button } from "./shadcn/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card";
+import { Input } from "./shadcn/input";
+import { Label } from "./shadcn/label";
+import { Textarea } from "./shadcn/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./shadcn/select";
+import { Checkbox } from "./shadcn/checkbox";
+import { Badge } from "./shadcn/badge";
+import {
+  Share2,
+  Copy,
+  Check,
+  Mail,
+  Link,
   MessageSquare,
   X,
   Users,
   Clock,
-  Eye
-} from "lucide-react"
-import { ScholarSearchResult } from "../../lib/ai-types"
+  Eye,
+} from "lucide-react";
+import { ScholarSearchResult } from "../../lib/ai-types";
 
 export interface ShareOptions {
-  shareType: 'link' | 'email' | 'embed'
-  includeScores: boolean
-  includeAbstracts: boolean
-  includePersonalNotes: boolean
-  expirationDays?: number
-  allowComments?: boolean
-  requireAuth?: boolean
-  customMessage?: string
-  recipientEmails?: string[]
+  shareType: "link" | "email" | "embed";
+  includeScores: boolean;
+  includeAbstracts: boolean;
+  includePersonalNotes: boolean;
+  expirationDays?: number;
+  allowComments?: boolean;
+  requireAuth?: boolean;
+  customMessage?: string;
+  recipientEmails?: string[];
 }
 
 export interface SharedResult {
-  id: string
-  results: ScholarSearchResult[]
-  shareOptions: ShareOptions
-  shareUrl: string
-  createdAt: Date
-  expiresAt?: Date
-  viewCount: number
-  isActive: boolean
+  id: string;
+  results: ScholarSearchResult[];
+  shareOptions: ShareOptions;
+  shareUrl: string;
+  createdAt: Date;
+  expiresAt?: Date;
+  viewCount: number;
+  isActive: boolean;
 }
 
 interface SearchResultSharingProps {
-  results: ScholarSearchResult[]
-  onShare: (results: ScholarSearchResult[], options: ShareOptions) => Promise<SharedResult>
-  onClose?: () => void
-  className?: string
+  results: ScholarSearchResult[];
+  onShare: (
+    results: ScholarSearchResult[],
+    options: ShareOptions,
+  ) => Promise<SharedResult>;
+  onClose?: () => void;
+  className?: string;
 }
 
 export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
   results,
   onShare,
   onClose,
-  className = ""
+  className = "",
 }) => {
   const [shareOptions, setShareOptions] = useState<ShareOptions>({
-    shareType: 'link',
+    shareType: "link",
     includeScores: true,
     includeAbstracts: true,
     includePersonalNotes: false,
     expirationDays: 30,
     allowComments: false,
     requireAuth: false,
-    customMessage: '',
-    recipientEmails: []
-  })
-  
-  const [isSharing, setIsSharing] = useState(false)
-  const [sharedResult, setSharedResult] = useState<SharedResult | null>(null)
-  const [copied, setCopied] = useState(false)
-  const [emailInput, setEmailInput] = useState('')
+    customMessage: "",
+    recipientEmails: [],
+  });
+
+  const [isSharing, setIsSharing] = useState(false);
+  const [sharedResult, setSharedResult] = useState<SharedResult | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [emailInput, setEmailInput] = useState("");
 
   const handleShare = async () => {
-    setIsSharing(true)
+    setIsSharing(true);
     try {
-      const result = await onShare(results, shareOptions)
-      setSharedResult(result)
+      const result = await onShare(results, shareOptions);
+      setSharedResult(result);
     } catch (error) {
-      console.error('Sharing failed:', error)
+      console.error("Sharing failed:", error);
     } finally {
-      setIsSharing(false)
+      setIsSharing(false);
     }
-  }
+  };
 
   const handleCopyLink = async () => {
-    if (!sharedResult) return
+    if (!sharedResult) return;
 
     try {
-      await navigator.clipboard.writeText(sharedResult.shareUrl)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      await navigator.clipboard.writeText(sharedResult.shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     } catch (error) {
-      console.error('Failed to copy to clipboard:', error)
+      console.error("Failed to copy to clipboard:", error);
     }
-  }
+  };
 
   const handleAddEmail = () => {
-    if (!emailInput.trim()) return
-    
-    const emails = emailInput.split(',').map(email => email.trim()).filter(email => email)
-    const validEmails = emails.filter(email => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
-    
+    if (!emailInput.trim()) return;
+
+    const emails = emailInput
+      .split(",")
+      .map((email) => email.trim())
+      .filter((email) => email);
+    const validEmails = emails.filter((email) =>
+      /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email),
+    );
+
     if (validEmails.length > 0) {
-      setShareOptions(prev => ({
+      setShareOptions((prev) => ({
         ...prev,
-        recipientEmails: [...(prev.recipientEmails || []), ...validEmails]
-      }))
-      setEmailInput('')
+        recipientEmails: [...(prev.recipientEmails || []), ...validEmails],
+      }));
+      setEmailInput("");
     }
-  }
+  };
 
   const handleRemoveEmail = (emailToRemove: string) => {
-    setShareOptions(prev => ({
+    setShareOptions((prev) => ({
       ...prev,
-      recipientEmails: prev.recipientEmails?.filter(email => email !== emailToRemove) || []
-    }))
-  }
+      recipientEmails:
+        prev.recipientEmails?.filter((email) => email !== emailToRemove) || [],
+    }));
+  };
 
   const updateShareOptions = (updates: Partial<ShareOptions>) => {
-    setShareOptions(prev => ({ ...prev, ...updates }))
-  }
+    setShareOptions((prev) => ({ ...prev, ...updates }));
+  };
 
   const getShareTypeIcon = (type: string) => {
     switch (type) {
-      case 'link':
-        return <Link className="h-4 w-4" />
-      case 'email':
-        return <Mail className="h-4 w-4" />
-      case 'embed':
-        return <MessageSquare className="h-4 w-4" />
+      case "link":
+        return <Link className="h-4 w-4" />;
+      case "email":
+        return <Mail className="h-4 w-4" />;
+      case "embed":
+        return <MessageSquare className="h-4 w-4" />;
       default:
-        return <Share2 className="h-4 w-4" />
+        return <Share2 className="h-4 w-4" />;
     }
-  }
+  };
 
   if (sharedResult) {
     return (
@@ -150,13 +165,18 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                 Results Shared Successfully
               </CardTitle>
               {onClose && (
-                <Button variant="ghost" size="sm" onClick={onClose}>
+                <Button
+                  aria-label="Close"
+                  variant="ghost"
+                  size="sm"
+                  onClick={onClose}
+                >
                   <X className="h-4 w-4" />
                 </Button>
               )}
             </div>
           </CardHeader>
-          
+
           <CardContent className="space-y-4">
             {/* Share URL */}
             <div className="space-y-2">
@@ -195,21 +215,21 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                   <span className="font-medium">Shared:</span>
                   <span>{results.length} results</span>
                 </div>
-                
+
                 <div className="flex items-center gap-2">
                   <Eye className="h-4 w-4 text-muted-foreground" />
                   <span className="font-medium">Views:</span>
                   <span>{sharedResult.viewCount}</span>
                 </div>
               </div>
-              
+
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
                   <Clock className="h-4 w-4 text-muted-foreground" />
                   <span className="font-medium">Created:</span>
                   <span>{sharedResult.createdAt.toLocaleDateString()}</span>
                 </div>
-                
+
                 {sharedResult.expiresAt && (
                   <div className="flex items-center gap-2">
                     <Clock className="h-4 w-4 text-muted-foreground" />
@@ -225,8 +245,11 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
               <Label>Share Settings</Label>
               <div className="flex flex-wrap gap-2">
                 <Badge variant="outline">
-                  {shareOptions.shareType === 'link' ? 'Public Link' : 
-                   shareOptions.shareType === 'email' ? 'Email Share' : 'Embed Code'}
+                  {shareOptions.shareType === "link"
+                    ? "Public Link"
+                    : shareOptions.shareType === "email"
+                      ? "Email Share"
+                      : "Embed Code"}
                 </Badge>
                 {shareOptions.includeScores && (
                   <Badge variant="outline">Includes Scores</Badge>
@@ -244,18 +267,20 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
             </div>
 
             {/* Email Recipients */}
-            {shareOptions.shareType === 'email' && shareOptions.recipientEmails && shareOptions.recipientEmails.length > 0 && (
-              <div className="space-y-2">
-                <Label>Email Recipients</Label>
-                <div className="flex flex-wrap gap-2">
-                  {shareOptions.recipientEmails.map((email, index) => (
-                    <Badge key={index} variant="outline">
-                      {email}
-                    </Badge>
-                  ))}
+            {shareOptions.shareType === "email" &&
+              shareOptions.recipientEmails &&
+              shareOptions.recipientEmails.length > 0 && (
+                <div className="space-y-2">
+                  <Label>Email Recipients</Label>
+                  <div className="flex flex-wrap gap-2">
+                    {shareOptions.recipientEmails.map((email, index) => (
+                      <Badge key={index} variant="outline">
+                        {email}
+                      </Badge>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
 
             {/* Custom Message */}
             {shareOptions.customMessage && (
@@ -269,7 +294,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
           </CardContent>
         </Card>
       </div>
-    )
+    );
   }
 
   return (
@@ -282,20 +307,29 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
               Share Search Results ({results.length} results)
             </CardTitle>
             {onClose && (
-              <Button variant="ghost" size="sm" onClick={onClose}>
+              <Button
+                aria-label="Close"
+                variant="ghost"
+                size="sm"
+                onClick={onClose}
+              >
                 <X className="h-4 w-4" />
               </Button>
             )}
           </div>
         </CardHeader>
-        
+
         <CardContent className="space-y-4">
           {/* Share Type Selection */}
           <div className="space-y-2">
             <Label>Share Method</Label>
-            <Select 
-              value={shareOptions.shareType} 
-              onValueChange={(value) => updateShareOptions({ shareType: value as 'link' | 'email' | 'embed' })}
+            <Select
+              value={shareOptions.shareType}
+              onValueChange={(value) =>
+                updateShareOptions({
+                  shareType: value as "link" | "email" | "embed",
+                })
+              }
             >
               <SelectTrigger>
                 <SelectValue />
@@ -324,7 +358,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
           </div>
 
           {/* Email Recipients (for email share type) */}
-          {shareOptions.shareType === 'email' && (
+          {shareOptions.shareType === "email" && (
             <div className="space-y-2">
               <Label>Email Recipients</Label>
               <div className="space-y-2">
@@ -333,7 +367,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                     value={emailInput}
                     onChange={(e) => setEmailInput(e.target.value)}
                     placeholder="Enter email addresses (comma-separated)"
-                    onKeyPress={(e) => e.key === 'Enter' && handleAddEmail()}
+                    onKeyPress={(e) => e.key === "Enter" && handleAddEmail()}
                   />
                   <Button
                     variant="outline"
@@ -343,22 +377,27 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                     Add
                   </Button>
                 </div>
-                
-                {shareOptions.recipientEmails && shareOptions.recipientEmails.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {shareOptions.recipientEmails.map((email, index) => (
-                      <Badge key={index} variant="outline" className="flex items-center gap-1">
-                        {email}
-                        <button
-                          onClick={() => handleRemoveEmail(email)}
-                          className="ml-1 hover:text-red-600"
+
+                {shareOptions.recipientEmails &&
+                  shareOptions.recipientEmails.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {shareOptions.recipientEmails.map((email, index) => (
+                        <Badge
+                          key={index}
+                          variant="outline"
+                          className="flex items-center gap-1"
                         >
-                          <X className="h-3 w-3" />
-                        </button>
-                      </Badge>
-                    ))}
-                  </div>
-                )}
+                          {email}
+                          <button
+                            onClick={() => handleRemoveEmail(email)}
+                            className="ml-1 hover:text-red-600"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
               </div>
             </div>
           )}
@@ -371,27 +410,39 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                 <Checkbox
                   id="include-scores"
                   checked={shareOptions.includeScores}
-                  onCheckedChange={(checked) => updateShareOptions({ includeScores: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateShareOptions({ includeScores: !!checked })
+                  }
                 />
-                <Label htmlFor="include-scores" className="text-sm">Include relevance and quality scores</Label>
+                <Label htmlFor="include-scores" className="text-sm">
+                  Include relevance and quality scores
+                </Label>
               </div>
-              
+
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="include-abstracts"
                   checked={shareOptions.includeAbstracts}
-                  onCheckedChange={(checked) => updateShareOptions({ includeAbstracts: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateShareOptions({ includeAbstracts: !!checked })
+                  }
                 />
-                <Label htmlFor="include-abstracts" className="text-sm">Include abstracts (when available)</Label>
+                <Label htmlFor="include-abstracts" className="text-sm">
+                  Include abstracts (when available)
+                </Label>
               </div>
-              
+
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="include-notes"
                   checked={shareOptions.includePersonalNotes}
-                  onCheckedChange={(checked) => updateShareOptions({ includePersonalNotes: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateShareOptions({ includePersonalNotes: !!checked })
+                  }
                 />
-                <Label htmlFor="include-notes" className="text-sm">Include personal notes and bookmarks</Label>
+                <Label htmlFor="include-notes" className="text-sm">
+                  Include personal notes and bookmarks
+                </Label>
               </div>
             </div>
           </div>
@@ -404,18 +455,26 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                 <Checkbox
                   id="require-auth"
                   checked={shareOptions.requireAuth}
-                  onCheckedChange={(checked) => updateShareOptions({ requireAuth: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateShareOptions({ requireAuth: !!checked })
+                  }
                 />
-                <Label htmlFor="require-auth" className="text-sm">Require authentication to view</Label>
+                <Label htmlFor="require-auth" className="text-sm">
+                  Require authentication to view
+                </Label>
               </div>
-              
+
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="allow-comments"
                   checked={shareOptions.allowComments}
-                  onCheckedChange={(checked) => updateShareOptions({ allowComments: !!checked })}
+                  onCheckedChange={(checked) =>
+                    updateShareOptions({ allowComments: !!checked })
+                  }
                 />
-                <Label htmlFor="allow-comments" className="text-sm">Allow viewers to add comments</Label>
+                <Label htmlFor="allow-comments" className="text-sm">
+                  Allow viewers to add comments
+                </Label>
               </div>
             </div>
           </div>
@@ -423,11 +482,14 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
           {/* Expiration */}
           <div className="space-y-2">
             <Label>Link Expiration</Label>
-            <Select 
-              value={shareOptions.expirationDays?.toString() || 'never'} 
-              onValueChange={(value) => updateShareOptions({ 
-                expirationDays: value === 'never' ? undefined : parseInt(value) 
-              })}
+            <Select
+              value={shareOptions.expirationDays?.toString() || "never"}
+              onValueChange={(value) =>
+                updateShareOptions({
+                  expirationDays:
+                    value === "never" ? undefined : parseInt(value),
+                })
+              }
             >
               <SelectTrigger>
                 <SelectValue />
@@ -448,8 +510,10 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
             <Label htmlFor="custom-message">Custom Message (optional)</Label>
             <Textarea
               id="custom-message"
-              value={shareOptions.customMessage || ''}
-              onChange={(e) => updateShareOptions({ customMessage: e.target.value })}
+              value={shareOptions.customMessage || ""}
+              onChange={(e) =>
+                updateShareOptions({ customMessage: e.target.value })
+              }
               placeholder="Add a personal message to share with the results..."
               rows={3}
             />
@@ -458,21 +522,30 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
           {/* Share Button */}
           <Button
             onClick={handleShare}
-            disabled={isSharing || results.length === 0 || 
-              (shareOptions.shareType === 'email' && (!shareOptions.recipientEmails || shareOptions.recipientEmails.length === 0))}
+            disabled={
+              isSharing ||
+              results.length === 0 ||
+              (shareOptions.shareType === "email" &&
+                (!shareOptions.recipientEmails ||
+                  shareOptions.recipientEmails.length === 0))
+            }
             className="w-full flex items-center gap-2"
           >
             {getShareTypeIcon(shareOptions.shareType)}
-            {isSharing ? 'Creating Share Link...' : `Share ${results.length} Results`}
+            {isSharing
+              ? "Creating Share Link..."
+              : `Share ${results.length} Results`}
           </Button>
 
-          {shareOptions.shareType === 'email' && (!shareOptions.recipientEmails || shareOptions.recipientEmails.length === 0) && (
-            <p className="text-sm text-muted-foreground text-center">
-              Please add at least one email recipient to share via email.
-            </p>
-          )}
+          {shareOptions.shareType === "email" &&
+            (!shareOptions.recipientEmails ||
+              shareOptions.recipientEmails.length === 0) && (
+              <p className="text-sm text-muted-foreground text-center">
+                Please add at least one email recipient to share via email.
+              </p>
+            )}
         </CardContent>
       </Card>
     </div>
-  )
-}
+  );
+};

--- a/src/components/ui/search-session-feedback.tsx
+++ b/src/components/ui/search-session-feedback.tsx
@@ -1,106 +1,108 @@
-"use client"
+"use client";
 
-import React, { useState } from "react"
-import { Button } from "./shadcn/button"
-import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card"
-import { Badge } from "./shadcn/badge"
-import { Textarea } from "./shadcn/textarea"
-import { Label } from "./shadcn/label"
-import { Checkbox } from "./shadcn/checkbox"
-import { 
-  Star, 
-  MessageSquare, 
+import React, { useState } from "react";
+import { Button } from "./shadcn/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./shadcn/card";
+import { Badge } from "./shadcn/badge";
+import { Textarea } from "./shadcn/textarea";
+import { Label } from "./shadcn/label";
+import { Checkbox } from "./shadcn/checkbox";
+import {
+  Star,
+  MessageSquare,
   X,
   Send,
   AlertCircle,
   ThumbsUp,
-  Lightbulb
-} from "lucide-react"
+  Lightbulb,
+} from "lucide-react";
 
 export interface SearchSessionFeedback {
-  searchSessionId: string
-  overallSatisfaction: number // 1-5 scale
-  relevanceRating: number // 1-5 scale
-  qualityRating: number // 1-5 scale
-  easeOfUseRating: number // 1-5 scale
-  feedbackComments?: string
-  wouldRecommend: boolean
-  improvementSuggestions?: string
-  timestamp: Date
+  searchSessionId: string;
+  overallSatisfaction: number; // 1-5 scale
+  relevanceRating: number; // 1-5 scale
+  qualityRating: number; // 1-5 scale
+  easeOfUseRating: number; // 1-5 scale
+  feedbackComments?: string;
+  wouldRecommend: boolean;
+  improvementSuggestions?: string;
+  timestamp: Date;
 }
 
 export interface SearchSessionFeedbackProps {
-  searchSessionId: string
-  searchQuery: string
-  resultsCount: number
-  onSubmitFeedback: (feedback: SearchSessionFeedback) => Promise<void>
-  onCancel?: () => void
-  className?: string
+  searchSessionId: string;
+  searchQuery: string;
+  resultsCount: number;
+  onSubmitFeedback: (feedback: SearchSessionFeedback) => Promise<void>;
+  onCancel?: () => void;
+  className?: string;
 }
 
-export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps> = ({
+export const SearchSessionFeedbackComponent: React.FC<
+  SearchSessionFeedbackProps
+> = ({
   searchSessionId,
   searchQuery,
   resultsCount,
   onSubmitFeedback,
   onCancel,
-  className = ""
+  className = "",
 }) => {
-  const [overallSatisfaction, setOverallSatisfaction] = useState<number>(0)
-  const [relevanceRating, setRelevanceRating] = useState<number>(0)
-  const [qualityRating, setQualityRating] = useState<number>(0)
-  const [easeOfUseRating, setEaseOfUseRating] = useState<number>(0)
-  const [feedbackComments, setFeedbackComments] = useState("")
-  const [wouldRecommend, setWouldRecommend] = useState(false)
-  const [improvementSuggestions, setImprovementSuggestions] = useState("")
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [overallSatisfaction, setOverallSatisfaction] = useState<number>(0);
+  const [relevanceRating, setRelevanceRating] = useState<number>(0);
+  const [qualityRating, setQualityRating] = useState<number>(0);
+  const [easeOfUseRating, setEaseOfUseRating] = useState<number>(0);
+  const [feedbackComments, setFeedbackComments] = useState("");
+  const [wouldRecommend, setWouldRecommend] = useState(false);
+  const [improvementSuggestions, setImprovementSuggestions] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleStarClick = (category: string, rating: number) => {
-    setError(null)
-    
+    setError(null);
+
     switch (category) {
-      case 'overall':
-        setOverallSatisfaction(rating)
-        break
-      case 'relevance':
-        setRelevanceRating(rating)
-        break
-      case 'quality':
-        setQualityRating(rating)
-        break
-      case 'easeOfUse':
-        setEaseOfUseRating(rating)
-        break
+      case "overall":
+        setOverallSatisfaction(rating);
+        break;
+      case "relevance":
+        setRelevanceRating(rating);
+        break;
+      case "quality":
+        setQualityRating(rating);
+        break;
+      case "easeOfUse":
+        setEaseOfUseRating(rating);
+        break;
     }
-  }
+  };
 
   const handleSubmit = async () => {
-    if (isSubmitting) return
+    if (isSubmitting) return;
 
     // Validate required fields
     if (overallSatisfaction === 0) {
-      setError('Please provide an overall satisfaction rating')
-      return
+      setError("Please provide an overall satisfaction rating");
+      return;
     }
 
     if (relevanceRating === 0) {
-      setError('Please rate the relevance of search results')
-      return
+      setError("Please rate the relevance of search results");
+      return;
     }
 
     if (qualityRating === 0) {
-      setError('Please rate the quality of search results')
-      return
+      setError("Please rate the quality of search results");
+      return;
     }
 
     if (easeOfUseRating === 0) {
-      setError('Please rate the ease of use')
-      return
+      setError("Please rate the ease of use");
+      return;
     }
 
-    setIsSubmitting(true)
-    setError(null)
+    setIsSubmitting(true);
+    setError(null);
 
     try {
       const feedback: SearchSessionFeedback = {
@@ -112,35 +114,35 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
         feedbackComments: feedbackComments.trim() || undefined,
         wouldRecommend,
         improvementSuggestions: improvementSuggestions.trim() || undefined,
-        timestamp: new Date()
-      }
+        timestamp: new Date(),
+      };
 
-      await onSubmitFeedback(feedback)
+      await onSubmitFeedback(feedback);
     } catch (error) {
-      console.error('Error submitting session feedback:', error)
-      setError('Failed to submit feedback. Please try again.')
+      console.error("Error submitting session feedback:", error);
+      setError("Failed to submit feedback. Please try again.");
     } finally {
-      setIsSubmitting(false)
+      setIsSubmitting(false);
     }
-  }
+  };
 
   const handleCancel = () => {
-    setOverallSatisfaction(0)
-    setRelevanceRating(0)
-    setQualityRating(0)
-    setEaseOfUseRating(0)
-    setFeedbackComments("")
-    setWouldRecommend(false)
-    setImprovementSuggestions("")
-    setError(null)
-    onCancel?.()
-  }
+    setOverallSatisfaction(0);
+    setRelevanceRating(0);
+    setQualityRating(0);
+    setEaseOfUseRating(0);
+    setFeedbackComments("");
+    setWouldRecommend(false);
+    setImprovementSuggestions("");
+    setError(null);
+    onCancel?.();
+  };
 
   const renderStarRating = (
-    category: string, 
-    currentRating: number, 
+    category: string,
+    currentRating: number,
     label: string,
-    description?: string
+    description?: string,
   ) => {
     return (
       <div className="space-y-2">
@@ -158,17 +160,17 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
               onClick={() => handleStarClick(category, star)}
               disabled={isSubmitting}
               className={`p-1 rounded transition-colors ${
-                !isSubmitting 
-                  ? 'hover:bg-gray-100 cursor-pointer' 
-                  : 'cursor-default'
+                !isSubmitting
+                  ? "hover:bg-gray-100 cursor-pointer"
+                  : "cursor-default"
               }`}
               aria-label={`Rate ${star} out of 5 stars for ${label}`}
             >
               <Star
                 className={`h-5 w-5 ${
                   star <= currentRating
-                    ? 'fill-yellow-400 text-yellow-400'
-                    : 'text-gray-300'
+                    ? "fill-yellow-400 text-yellow-400"
+                    : "text-gray-300"
                 }`}
               />
             </button>
@@ -180,22 +182,31 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
           )}
         </div>
       </div>
-    )
-  }
+    );
+  };
 
   const getRatingLabel = (rating: number): string => {
     switch (rating) {
-      case 1: return 'Poor'
-      case 2: return 'Fair'
-      case 3: return 'Good'
-      case 4: return 'Very Good'
-      case 5: return 'Excellent'
-      default: return ''
+      case 1:
+        return "Poor";
+      case 2:
+        return "Fair";
+      case 3:
+        return "Good";
+      case 4:
+        return "Very Good";
+      case 5:
+        return "Excellent";
+      default:
+        return "";
     }
-  }
+  };
 
-  const isFormValid = overallSatisfaction > 0 && relevanceRating > 0 && 
-                     qualityRating > 0 && easeOfUseRating > 0
+  const isFormValid =
+    overallSatisfaction > 0 &&
+    relevanceRating > 0 &&
+    qualityRating > 0 &&
+    easeOfUseRating > 0;
 
   return (
     <Card className={`${className}`}>
@@ -206,6 +217,7 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
             Search Feedback
           </CardTitle>
           <Button
+            aria-label="Close"
             variant="ghost"
             size="sm"
             onClick={handleCancel}
@@ -214,44 +226,48 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
             <X className="h-3 w-3" />
           </Button>
         </div>
-        
+
         <div className="text-sm text-muted-foreground space-y-1">
-          <p><strong>Search Query:</strong> {searchQuery}</p>
-          <p><strong>Results Found:</strong> {resultsCount}</p>
+          <p>
+            <strong>Search Query:</strong> {searchQuery}
+          </p>
+          <p>
+            <strong>Results Found:</strong> {resultsCount}
+          </p>
         </div>
       </CardHeader>
 
       <CardContent className="space-y-6">
         {/* Overall Satisfaction */}
         {renderStarRating(
-          'overall',
+          "overall",
           overallSatisfaction,
-          'Overall Satisfaction',
-          'How satisfied are you with this search experience?'
+          "Overall Satisfaction",
+          "How satisfied are you with this search experience?",
         )}
 
         {/* Relevance Rating */}
         {renderStarRating(
-          'relevance',
+          "relevance",
           relevanceRating,
-          'Result Relevance',
-          'How relevant were the search results to your query?'
+          "Result Relevance",
+          "How relevant were the search results to your query?",
         )}
 
         {/* Quality Rating */}
         {renderStarRating(
-          'quality',
+          "quality",
           qualityRating,
-          'Result Quality',
-          'How would you rate the quality of the academic papers found?'
+          "Result Quality",
+          "How would you rate the quality of the academic papers found?",
         )}
 
         {/* Ease of Use Rating */}
         {renderStarRating(
-          'easeOfUse',
+          "easeOfUse",
           easeOfUseRating,
-          'Ease of Use',
-          'How easy was it to use the AI search feature?'
+          "Ease of Use",
+          "How easy was it to use the AI search feature?",
         )}
 
         {/* Would Recommend */}
@@ -261,15 +277,17 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
             <Checkbox
               id="would-recommend"
               checked={wouldRecommend}
-              onCheckedChange={(checked) => setWouldRecommend(checked as boolean)}
+              onCheckedChange={(checked) =>
+                setWouldRecommend(checked as boolean)
+              }
               disabled={isSubmitting}
             />
-            <Label 
-              htmlFor="would-recommend" 
+            <Label
+              htmlFor="would-recommend"
               className="text-sm cursor-pointer flex items-center gap-2"
             >
-              <ThumbsUp className="h-4 w-4 text-green-600" />
-              I would recommend this AI search feature to others
+              <ThumbsUp className="h-4 w-4 text-green-600" />I would recommend
+              this AI search feature to others
             </Label>
           </div>
         </div>
@@ -295,7 +313,10 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
 
         {/* Improvement Suggestions */}
         <div className="space-y-2">
-          <Label htmlFor="improvement-suggestions" className="text-sm font-medium flex items-center gap-2">
+          <Label
+            htmlFor="improvement-suggestions"
+            className="text-sm font-medium flex items-center gap-2"
+          >
             <Lightbulb className="h-4 w-4 text-yellow-600" />
             Suggestions for Improvement (Optional)
           </Label>
@@ -316,12 +337,25 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
         {/* Rating Summary */}
         {isFormValid && (
           <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-            <div className="text-sm font-medium text-blue-800 mb-2">Feedback Summary</div>
+            <div className="text-sm font-medium text-blue-800 mb-2">
+              Feedback Summary
+            </div>
             <div className="grid grid-cols-2 gap-2 text-xs text-blue-700">
-              <div>Overall: {getRatingLabel(overallSatisfaction)} ({overallSatisfaction}/5)</div>
-              <div>Relevance: {getRatingLabel(relevanceRating)} ({relevanceRating}/5)</div>
-              <div>Quality: {getRatingLabel(qualityRating)} ({qualityRating}/5)</div>
-              <div>Ease of Use: {getRatingLabel(easeOfUseRating)} ({easeOfUseRating}/5)</div>
+              <div>
+                Overall: {getRatingLabel(overallSatisfaction)} (
+                {overallSatisfaction}/5)
+              </div>
+              <div>
+                Relevance: {getRatingLabel(relevanceRating)} ({relevanceRating}
+                /5)
+              </div>
+              <div>
+                Quality: {getRatingLabel(qualityRating)} ({qualityRating}/5)
+              </div>
+              <div>
+                Ease of Use: {getRatingLabel(easeOfUseRating)} (
+                {easeOfUseRating}/5)
+              </div>
             </div>
             {wouldRecommend && (
               <div className="text-xs text-blue-700 mt-2 flex items-center gap-1">
@@ -357,10 +391,10 @@ export const SearchSessionFeedbackComponent: React.FC<SearchSessionFeedbackProps
             className="flex items-center gap-2"
           >
             <Send className="h-4 w-4" />
-            {isSubmitting ? 'Submitting...' : 'Submit Feedback'}
+            {isSubmitting ? "Submitting..." : "Submit Feedback"}
           </Button>
         </div>
       </CardContent>
     </Card>
-  )
-}
+  );
+};

--- a/test-script.js
+++ b/test-script.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+
+function findMissingAriaLabels(dir) {
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+        const fullPath = `${dir}/${file}`;
+        if (fs.statSync(fullPath).isDirectory()) {
+            findMissingAriaLabels(fullPath);
+        } else if (file.endsWith('.tsx')) {
+            const content = fs.readFileSync(fullPath, 'utf-8');
+            // Simplified check: look for Button with variant="ghost" or size="icon" and an icon component
+            // but missing aria-label
+            const regex = /<Button[^>]*?(variant="ghost"|size="icon")[^>]*?>\s*<[A-Z][a-zA-Z]* [^>]*\/>\s*(?!<span class[^>]*sr-only|<\/span>|.*aria-label)(.*?)<\/Button>/gs;
+            let match;
+            while ((match = regex.exec(content)) !== null) {
+                // If it doesn't contain text nodes or sr-only
+                if (!content.substring(match.index, match.index + match[0].length).includes('sr-only') && !content.substring(match.index, match.index + match[0].length).includes('aria-label')) {
+                    console.log(`Potential missing aria-label in ${fullPath}:`);
+                    console.log(match[0]);
+                    console.log('---');
+                }
+            }
+        }
+    }
+}
+
+findMissingAriaLabels('src/components');


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to icon-only buttons across 10 UI components. Added `aria-label="Close"` for `<X />`, `aria-label="Copy citation"` for `<Copy />`, and `aria-label="Open external link"` for `<ExternalLink />`. Also recorded a new journal entry in `.Jules/palette.md` for this recurring accessibility pattern.

🎯 **Why:** To improve accessibility. Icon-only buttons (using `size="icon"` or `variant="ghost"`) are completely inaccessible to screen reader users if they lack text nodes or `aria-label`s, as they provide no context for the button's action.

📸 **Before/After:** Not applicable (non-visual change).

♿ **Accessibility:** Screen readers will now correctly announce "Close", "Copy citation", or "Open external link" instead of just "Button" when navigating to these actions in modals, dialogs, and panels.

---
*PR created automatically by Jules for task [2135534020466671568](https://jules.google.com/task/2135534020466671568) started by @njtan142*