### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in reference form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-03-09 - Missing ARIA labels in dynamic/interactive chat components
 **Learning:** Icon-only buttons in the core Chat component (`src/components/ui/chat.tsx`), particularly actions like "Thumbs up", "Thumbs down", and "Scroll to bottom", were missing `aria-label` attributes. Screen reader users would have no context for what these buttons do since they lack text nodes.
 **Action:** When implementing new features or components with interactive icon-only buttons (`size="icon"`), proactively add descriptive `aria-label` attributes.
+## 2024-03-28 - Icon-Only Buttons in Array Inputs Need ARIA Labels
+**Learning:** Icon-only buttons for repetitive actions within arrays (like adding/removing items in dynamic lists) are frequently missed and require explicit `aria-label`s to ensure accessibility.
+**Action:** When implementing forms with dynamic arrays or lists, always add explicit `aria-label` attributes to the associated add/remove icon buttons.

--- a/src/components/ui/reference-form.tsx
+++ b/src/components/ui/reference-form.tsx
@@ -229,7 +229,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
           <CardTitle>
             {isEditing ? 'Edit Reference' : 'Add New Reference'}
           </CardTitle>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close">
             <X className="h-4 w-4" />
           </Button>
         </div>
@@ -282,7 +282,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   placeholder="Add author name"
                   onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addAuthor())}
                 />
-                <Button type="button" onClick={addAuthor} size="sm">
+                <Button type="button" onClick={addAuthor} size="sm" aria-label="Add author">
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -294,6 +294,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeAuthor(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove author"
                     >
                       <X className="h-3 w-3" />
                     </button>
@@ -454,7 +455,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   placeholder="Add tag"
                   onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
                 />
-                <Button type="button" onClick={addTag} size="sm">
+                <Button type="button" onClick={addTag} size="sm" aria-label="Add tag">
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -466,6 +467,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeTag(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove tag"
                     >
                       <X className="h-3 w-3" />
                     </button>


### PR DESCRIPTION
💡 What: Added explicit `aria-label` attributes to the icon-only buttons (Close, Add author, Remove author, Add tag, Remove tag) within `src/components/ui/reference-form.tsx`.
🎯 Why: Icon-only buttons lack visible text, making them completely inaccessible to users relying on screen readers. Adding `aria-label`s provides the necessary context for what these buttons do.
📸 Before/After: N/A - purely semantic change affecting screen readers. (A screenshot and video verifying the layout wasn't negatively affected is attached).
♿ Accessibility: Improved screen reader navigation and comprehension by ensuring all interactive elements in the reference form have a programmatic accessible name.

---
*PR created automatically by Jules for task [3857822302378341184](https://jules.google.com/task/3857822302378341184) started by @njtan142*