### PR TITLE
⚡ Bolt: [performance improvement] fix N+1 in query performance analytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+
+## 2026-03-28 - D1 SQLite N+1 Queries in Promise.all map loops
+**Learning:** Fetching aggregated "top 3" database records by looping over an array and executing a `LIMIT 3` query for each element inside a `Promise.all` loop causes a massive N+1 query burst. Cloudflare D1 (SQLite) supports window functions, allowing us to combine this logic into a single database round-trip.
+**Action:** Replace `Promise.all` inside `.map` loops with a CTE `ROW_NUMBER() OVER(PARTITION BY parent_id ORDER BY score DESC)` query, then map the grouped results back to the original array in memory.

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -315,43 +315,62 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
       `;
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
+      const queries = result.results || [];
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
-            ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+      if (queries.length === 0) {
+        return [];
+      }
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      // Optimize N+1 query problem by fetching top results for all queries in a single trip
+      const searchQueries = queries.map((r: any) => r.search_query);
+      const placeholders = searchQueries.map(() => '?').join(',');
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      const topResultsQuery = `
+        WITH RankedResults AS (
+          SELECT
+            ss.search_query,
+            sr.result_title,
+            sr.relevance_score,
+            sr.added_to_library,
+            ROW_NUMBER() OVER(PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.search_query IN (${placeholders}) AND ss.user_id = ?
+          ${conversationId ? 'AND ss.conversation_id = ?' : ''}
+        )
+        SELECT * FROM RankedResults WHERE rn <= 3
+      `;
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      const topResultsParams = [...searchQueries, userId];
+      if (conversationId) {
+        topResultsParams.push(conversationId);
+      }
+
+      const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
+
+      // Group results by query
+      const topResultsMap = new Map<string, Array<any>>();
+      (topResultsResult.results || []).forEach((r: any) => {
+        const q = r.search_query;
+        if (!topResultsMap.has(q)) {
+          topResultsMap.set(q, []);
+        }
+        topResultsMap.get(q)!.push({
+          title: r.result_title,
+          relevanceScore: r.relevance_score,
+          addedToLibrary: r.added_to_library
+        });
+      });
+
+      const queryAnalytics = queries.map((row: any) => ({
+        query: row.search_query,
+        searchCount: row.search_count,
+        averageResults: row.avg_results || 0,
+        successRate: row.success_rate || 0,
+        averageProcessingTime: row.avg_processing_time || 0,
+        lastUsed: new Date(row.last_used),
+        topResults: topResultsMap.get(row.search_query) || []
+      }));
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
💡 **What:** 
Replaced a `Promise.all` `.map` loop executing `N` separate `LIMIT 3` database queries with a single, grouped database query utilizing the SQLite window function `ROW_NUMBER() OVER(PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC)`.

🎯 **Why:** 
The previous implementation in `getQueryPerformanceAnalytics` fetched the "top 3 results" for up to 20 different queries concurrently inside a `.map` loop. This generated an "N+1 query" anti-pattern. By consolidating this into a single Common Table Expression (CTE) query, we eliminate redundant network/database round-trips.

📊 **Impact:** 
Reduces database roundtrips from `1 + N` (where N is up to 20) down to just `2` queries total. This will dramatically improve response time and reduce load on the D1 database instance when compiling performance analytics for users.

🔬 **Measurement:** 
Review `EnhancedSearchHistoryManager.getQueryPerformanceAnalytics`. You can profile the `/api/history/stats` or related endpoint and see exactly 2 queries being dispatched rather than up to 21.

---
*PR created automatically by Jules for task [13339841739259260982](https://jules.google.com/task/13339841739259260982) started by @njtan142*