### PR TITLE
⚡ Bolt: Optimize getConcernStatistics performance

### DIFF
--- a/src/worker/lib/concern-status-manager.ts
+++ b/src/worker/lib/concern-status-manager.ts
@@ -112,72 +112,95 @@ export class ConcernStatusManagerImpl implements ConcernStatusManager {
     try {
       const concerns = await this.getConcernsByStatus(conversationId);
       
-      // Calculate overall statistics
+      // Calculate overall statistics in a single pass
       const total = concerns.length;
-      const toBeDone = concerns.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-      const addressed = concerns.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-      const rejected = concerns.filter(c => c.status === ConcernStatus.REJECTED).length;
+      let toBeDone = 0;
+      let addressed = 0;
+      let rejected = 0;
 
-      // Calculate statistics by category
-      const byCategory: Record<ConcernCategory, ConcernStatusBreakdown> = {} as Record<ConcernCategory, ConcernStatusBreakdown>;
-      
+      const concernsByStatus = {
+        [ConcernStatus.OPEN]: 0,
+        [ConcernStatus.RESOLVED]: 0,
+        [ConcernStatus.DISMISSED]: 0,
+        [ConcernStatus.ADDRESSED]: 0,
+        [ConcernStatus.REJECTED]: 0,
+        [ConcernStatus.TO_BE_DONE]: 0
+      } as Record<ConcernStatus, number>;
+
+      const concernsByCategory = {} as Record<ConcernCategory, number>;
+      const byCategoryRaw = {} as Record<ConcernCategory, { total: number, toBeDone: number, addressed: number, rejected: number }>;
+
+      const concernsBySeverity = {} as Record<ConcernSeverity, number>;
+      const bySeverityRaw = {} as Record<ConcernSeverity, { total: number, toBeDone: number, addressed: number, rejected: number }>;
+
+      // Initialize structures
       Object.values(ConcernCategory).forEach(category => {
-        const categoryData = concerns.filter(c => c.category === category);
-        const total = categoryData.length;
-        const toBeDone = categoryData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-        const addressed = categoryData.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-        const rejected = categoryData.filter(c => c.status === ConcernStatus.REJECTED).length;
+        concernsByCategory[category] = 0;
+        byCategoryRaw[category] = { total: 0, toBeDone: 0, addressed: 0, rejected: 0 };
+      });
+      
+      Object.values(ConcernSeverity).forEach(severity => {
+        concernsBySeverity[severity] = 0;
+        bySeverityRaw[severity] = { total: 0, toBeDone: 0, addressed: 0, rejected: 0 };
+      });
+
+      // Single pass to accumulate all stats
+      for (const c of concerns) {
+        // Update overall counts
+        if (c.status === ConcernStatus.TO_BE_DONE) toBeDone++;
+        else if (c.status === ConcernStatus.ADDRESSED) addressed++;
+        else if (c.status === ConcernStatus.REJECTED) rejected++;
+
+        // Update by status
+        if (concernsByStatus[c.status] !== undefined) concernsByStatus[c.status]++;
+
+        // Update by category
+        if (c.category && concernsByCategory[c.category] !== undefined) {
+          concernsByCategory[c.category]++;
+          byCategoryRaw[c.category].total++;
+          if (c.status === ConcernStatus.TO_BE_DONE) byCategoryRaw[c.category].toBeDone++;
+          else if (c.status === ConcernStatus.ADDRESSED) byCategoryRaw[c.category].addressed++;
+          else if (c.status === ConcernStatus.REJECTED) byCategoryRaw[c.category].rejected++;
+        }
+
+        // Update by severity
+        if (c.severity && concernsBySeverity[c.severity] !== undefined) {
+          concernsBySeverity[c.severity]++;
+          bySeverityRaw[c.severity].total++;
+          if (c.status === ConcernStatus.TO_BE_DONE) bySeverityRaw[c.severity].toBeDone++;
+          else if (c.status === ConcernStatus.ADDRESSED) bySeverityRaw[c.severity].addressed++;
+          else if (c.status === ConcernStatus.REJECTED) bySeverityRaw[c.severity].rejected++;
+        }
+      }
+
+      // Calculate final breakdown statistics by category
+      const byCategory: Record<ConcernCategory, ConcernStatusBreakdown> = {} as Record<ConcernCategory, ConcernStatusBreakdown>;
+      Object.values(ConcernCategory).forEach(category => {
+        const raw = byCategoryRaw[category];
         byCategory[category] = {
           status: category as unknown as ConcernStatus, // This is a workaround - category is a ConcernCategory, not ConcernStatus
-          count: total,
-          percentage: total > 0 ? (addressed / total) * 100 : 0,
-          total,
-          toBeDone,
-          addressed,
-          rejected
+          count: raw.total,
+          percentage: raw.total > 0 ? (raw.addressed / raw.total) * 100 : 0,
+          total: raw.total,
+          toBeDone: raw.toBeDone,
+          addressed: raw.addressed,
+          rejected: raw.rejected
         };
       });
 
-      // Calculate statistics by severity
+      // Calculate final breakdown statistics by severity
       const bySeverity: Record<ConcernSeverity, ConcernStatusBreakdown> = {} as Record<ConcernSeverity, ConcernStatusBreakdown>;
-      
       Object.values(ConcernSeverity).forEach(severity => {
-        const severityData = concerns.filter(c => c.severity === severity);
-        const total = severityData.length;
-        const toBeDone = severityData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-        const addressed = severityData.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-        const rejected = severityData.filter(c => c.status === ConcernStatus.REJECTED).length;
+        const raw = bySeverityRaw[severity];
         bySeverity[severity] = {
           status: severity as unknown as ConcernStatus, // This is a workaround - severity is a ConcernSeverity, not ConcernStatus
-          count: total,
-          percentage: total > 0 ? (addressed / total) * 100 : 0,
-          total,
-          toBeDone,
-          addressed,
-          rejected
+          count: raw.total,
+          percentage: raw.total > 0 ? (raw.addressed / raw.total) * 100 : 0,
+          total: raw.total,
+          toBeDone: raw.toBeDone,
+          addressed: raw.addressed,
+          rejected: raw.rejected
         };
-      });
-
-      // Calculate concerns by status
-      const concernsByStatus: Record<ConcernStatus, number> = {
-        [ConcernStatus.OPEN]: concerns.filter(c => c.status === ConcernStatus.OPEN).length,
-        [ConcernStatus.RESOLVED]: concerns.filter(c => c.status === ConcernStatus.RESOLVED).length,
-        [ConcernStatus.DISMISSED]: concerns.filter(c => c.status === ConcernStatus.DISMISSED).length,
-        [ConcernStatus.ADDRESSED]: addressed,
-        [ConcernStatus.REJECTED]: rejected,
-        [ConcernStatus.TO_BE_DONE]: toBeDone
-      };
-
-      // Calculate concerns by category
-      const concernsByCategory: Record<ConcernCategory, number> = {} as Record<ConcernCategory, number>;
-      Object.values(ConcernCategory).forEach(category => {
-        concernsByCategory[category] = concerns.filter(c => c.category === category).length;
-      });
-
-      // Calculate concerns by severity
-      const concernsBySeverity: Record<ConcernSeverity, number> = {} as Record<ConcernSeverity, number>;
-      Object.values(ConcernSeverity).forEach(severity => {
-        concernsBySeverity[severity] = concerns.filter(c => c.severity === severity).length;
       });
 
       // Calculate resolution rate (simple calculation)


### PR DESCRIPTION
💡 What: Replaced 10+ consecutive `.filter(...).length` iterations in `getConcernStatistics` with a single loop that accumulates all status, category, and severity counts simultaneously.

🎯 Why: The original implementation caused O(k*N) time complexity where N is the number of concerns and k is the number of categories and severities (e.g., iterating through all concerns for 'OPEN', then 'RESOLVED', then 'grammar', then 'style', etc.). This resulted in redundant array traversals and unnecessary overhead, especially for conversations with a large number of concerns.

📊 Impact: Reduces array traversals by ~95% inside `getConcernStatistics`. Instead of iterating through the `concerns` array roughly 50+ times, it now iterates exactly once, turning an O(k*N) operation into an O(N) operation.

🔬 Measurement: Verify that `bun test src/tests/concern-status-manager.test.ts` still passes its underlying logic structure correctly and that the worker route utilizing `getConcernStatistics` processes payloads slightly faster under load.

---
*PR created automatically by Jules for task [1505666424313006128](https://jules.google.com/task/1505666424313006128) started by @njtan142*