### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in Reference Form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-03-29 - Add ARIA labels to dynamic list actions
+**Learning:** Icon-only buttons in dynamic arrays (like adding/removing authors and tags) are frequently missed during accessibility audits, rendering them completely inaccessible to screen readers.
+**Action:** Always ensure an explicit `aria-label` is added to repetitive array actions and dialog close buttons when they consist solely of icons.

--- a/src/components/ui/reference-form.tsx
+++ b/src/components/ui/reference-form.tsx
@@ -229,7 +229,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
           <CardTitle>
             {isEditing ? 'Edit Reference' : 'Add New Reference'}
           </CardTitle>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close form">
             <X className="h-4 w-4" />
           </Button>
         </div>
@@ -282,7 +282,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   placeholder="Add author name"
                   onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addAuthor())}
                 />
-                <Button type="button" onClick={addAuthor} size="sm">
+                <Button type="button" onClick={addAuthor} size="sm" aria-label="Add author">
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -294,6 +294,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeAuthor(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove author"
                     >
                       <X className="h-3 w-3" />
                     </button>
@@ -454,7 +455,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   placeholder="Add tag"
                   onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
                 />
-                <Button type="button" onClick={addTag} size="sm">
+                <Button type="button" onClick={addTag} size="sm" aria-label="Add tag">
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -466,6 +467,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeTag(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove tag"
                     >
                       <X className="h-3 w-3" />
                     </button>


### PR DESCRIPTION
### 💡 What:
Added explicit `aria-label` attributes to the five icon-only buttons in the `ReferenceForm` component (`src/components/ui/reference-form.tsx`):
- Close form (`aria-label="Close form"`)
- Add Author (`aria-label="Add author"`)
- Remove Author (`aria-label="Remove author"`)
- Add Tag (`aria-label="Add tag"`)
- Remove Tag (`aria-label="Remove tag"`)

### 🎯 Why:
Icon-only buttons, especially those used for repetitive array actions (like adding or removing items in a dynamic list), are frequently missed during accessibility audits. Without an `aria-label` or visible text, screen readers cannot announce the button's purpose to users, rendering the controls completely inaccessible.

### ♿ Accessibility:
Improved keyboard and screen reader accessibility by ensuring all interactive controls in the Reference Form have a clear, programmatic name describing their action.

---
*PR created automatically by Jules for task [5552774601720585180](https://jules.google.com/task/5552774601720585180) started by @njtan142*