### PR TITLE
🎨 Palette: [Accessibility] Add ARIA label to ToolsPanel toggle button

### DIFF
--- a/src/components/ui/chat.tsx
+++ b/src/components/ui/chat.tsx
@@ -243,7 +243,6 @@ export function Chat({
             size="icon"
             variant="ghost"
             className="h-6 w-6"
-            aria-label="Rate response as helpful"
             onClick={() => onRateResponse(message.id, "thumbs-up")}
             aria-label="Rate response as helpful"
           >
@@ -253,7 +252,6 @@ export function Chat({
             size="icon"
             variant="ghost"
             className="h-6 w-6"
-            aria-label="Rate response as unhelpful"
             onClick={() => onRateResponse(message.id, "thumbs-down")}
             aria-label="Rate response as unhelpful"
           >

--- a/src/components/ui/tools-panel.tsx
+++ b/src/components/ui/tools-panel.tsx
@@ -53,6 +53,7 @@ export const ToolsPanel: React.FC<ToolsPanelProps> = ({
         variant="ghost"
         size="icon"
         onClick={() => setIsOpen(!isOpen)}
+        aria-label={isOpen ? "Close tools panel" : "Open tools panel"}
         className={cn(
           "absolute top-4 z-10 h-8 w-8 rounded-full border bg-background shadow-sm hover:bg-muted transition-all duration-300",
           isOpen


### PR DESCRIPTION
💡 **What:** 
- Added a dynamic `aria-label` to the main chevron `<Button>` in `ToolsPanel` (`src/components/ui/tools-panel.tsx`) that changes between "Open tools panel" and "Close tools panel" based on its state.
- Removed duplicate `aria-label` properties on the "thumbs-up" and "thumbs-down" `<Button>` components in `Chat` (`src/components/ui/chat.tsx`).

🎯 **Why:** 
- Icon-only buttons must have `aria-label` attributes to be accessible to screen readers. The `ToolsPanel` toggle button previously had no accessible name.
- Duplicate properties in JSX components can cause React warnings and visual clutter in code.

♿ **Accessibility:** 
- The tools panel toggle is now fully accessible to keyboard and screen reader users, accurately announcing its function based on the panel's open/closed state.
- No change in visual appearance.

---
*PR created automatically by Jules for task [15030363067835648760](https://jules.google.com/task/15030363067835648760) started by @njtan142*