### PR TITLE
🎨 Palette: Add ARIA labels to icon-only action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Missing ARIA labels on dynamic array item removal and dialog close buttons
+**Learning:** In this application's components, a recurring pattern is rendering dynamic array items (like authors, tags, or shared emails) inside Badges with a nested icon-only `<button>` to remove them. Similarly, modal/dialog headers often use an `<X>` icon within a Button for closing. These frequently lack `aria-label`s, rendering them inaccessible to screen readers as the buttons contain no semantic text.
+**Action:** When creating or reviewing components with dynamic list manipulation or custom dialog headers, explicitly ensure that any `<button>` containing only an icon has a context-aware `aria-label` (e.g., `aria-label="Remove author"` or `aria-label="Close dialog"`).

--- a/src/components/ui/concern-list.tsx
+++ b/src/components/ui/concern-list.tsx
@@ -477,6 +477,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => onFilterChange('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear status filter"
                 >
                   ×
                 </button>
@@ -488,6 +489,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => setCategoryFilter('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear category filter"
                 >
                   ×
                 </button>
@@ -499,6 +501,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => setSeverityFilter('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear severity filter"
                 >
                   ×
                 </button>

--- a/src/components/ui/reference-detail.tsx
+++ b/src/components/ui/reference-detail.tsx
@@ -334,6 +334,7 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
             variant="ghost"
             size="sm"
             onClick={onClose}
+            aria-label="Close detail"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -503,6 +504,7 @@ export const ReferenceDetail: React.FC<ReferenceDetailProps> = ({
                       <button
                         onClick={() => handleRemoveTag(tag)}
                         className="ml-2 hover:text-destructive"
+                        aria-label="Remove tag"
                       >
                         <X className="h-3 w-3" />
                       </button>

--- a/src/components/ui/reference-form.tsx
+++ b/src/components/ui/reference-form.tsx
@@ -229,7 +229,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
           <CardTitle>
             {isEditing ? 'Edit Reference' : 'Add New Reference'}
           </CardTitle>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close form">
             <X className="h-4 w-4" />
           </Button>
         </div>
@@ -294,6 +294,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeAuthor(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove author"
                     >
                       <X className="h-3 w-3" />
                     </button>
@@ -466,6 +467,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeTag(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove tag"
                     >
                       <X className="h-3 w-3" />
                     </button>

--- a/src/components/ui/search-result-sharing.tsx
+++ b/src/components/ui/search-result-sharing.tsx
@@ -150,7 +150,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                 Results Shared Successfully
               </CardTitle>
               {onClose && (
-                <Button variant="ghost" size="sm" onClick={onClose}>
+                <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close dialog">
                   <X className="h-4 w-4" />
                 </Button>
               )}
@@ -282,7 +282,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
               Share Search Results ({results.length} results)
             </CardTitle>
             {onClose && (
-              <Button variant="ghost" size="sm" onClick={onClose}>
+              <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close dialog">
                 <X className="h-4 w-4" />
               </Button>
             )}
@@ -352,6 +352,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                         <button
                           onClick={() => handleRemoveEmail(email)}
                           className="ml-1 hover:text-red-600"
+                          aria-label="Remove email"
                         >
                           <X className="h-3 w-3" />
                         </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` properties to multiple icon-only action buttons across UI components: `reference-form`, `reference-detail`, `search-result-sharing`, and `concern-list`. These include dialog "close" buttons, badge "remove" buttons for tags/authors/emails, and filter "clear" buttons.
🎯 **Why**: When visually rendering dynamic arrays using items like tags or categories, the `X` or close icon buttons within them lacked semantic names. Screen readers cannot infer the functionality of these buttons, reducing usability for users depending on assistive tech.
📸 **Before/After**: Visually unchanged; underlying `aria-label` attributes added.
♿ **Accessibility**: Enhanced screen reader support by providing explicit contextual names, making dynamic interactions (like managing tags/authors or closing lists) navigable without sight.

---
*PR created automatically by Jules for task [1657013315963672784](https://jules.google.com/task/1657013315963672784) started by @njtan142*