### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR and missing auth in profile endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,9 @@
 **Vulnerability:** The application is using `origin: '*'` together with `credentials: true` in Hono CORS configuration (`src/worker/routes/auth-routes.ts`).
 **Learning:** Using a wildcard origin with credentials enabled allows any website to make requests to the authenticated endpoints and include the user's cookies/credentials. This is a significant security risk and can lead to CSRF attacks or data theft.
 **Prevention:** Avoid using `origin: '*'` with `credentials: true`. Instead, implement a dynamic origin resolver function utilizing `c.env` or `import.meta.env` to strictly validate against allowed frontend URLs and development environments.
+## 2025-04-02 - IDOR and Missing Authentication in User Profile and Password Routes
+**Vulnerability:** The sensitive user profile endpoints (`GET /profile/:userId`, `PUT /profile/:userId`, and `POST /change-password/:userId`) in `src/worker/routes/auth-routes.ts` lacked the `requireAuth` middleware. Additionally, their respective handlers in `src/worker/handlers/auth.ts` blindly trusted the `userId` passed in the URL path parameters without cross-checking against the authenticated user's context.
+**Learning:** This is a classic Insecure Direct Object Reference (IDOR) pattern coupled with missing authentication checks. Although these routes were commented as "Protected routes (authentication required)", the protection was missing from the router bindings, and the handlers lacked the defensive assertion that the user requesting or modifying the data is the actual owner of the resource.
+**Prevention:**
+1. Always apply the `requireAuth` middleware on sensitive user-specific API routes.
+2. Inside the handler, explicitly extract the `authContext` using `getAuthContext(c)` and compare `authContext.userId` with the requested resource's owner (e.g., `c.req.param('userId')`), returning `403 Forbidden` if they mismatch.

--- a/src/worker/handlers/auth.ts
+++ b/src/worker/handlers/auth.ts
@@ -2,6 +2,7 @@
  * Authentication Handlers - HTTP handlers for auth endpoints
  */
 import { Context } from 'hono';
+import { getAuthContext } from '../middleware/auth-middleware';
 import {
   registerUser,
   loginUser,
@@ -106,6 +107,14 @@ export async function getUserProfileHandler(c: Context) {
       );
     }
 
+    const authContext = getAuthContext(c);
+    if (!authContext || authContext.userId !== userId) {
+      return c.json(
+        { success: false, error: 'Unauthorized access to user profile' },
+        403
+      );
+    }
+
     const result = await getUserProfile(userId);
 
     return c.json(result, 200);
@@ -130,6 +139,14 @@ export async function updateUserProfileHandler(c: Context) {
       return c.json(
         { success: false, error: 'User ID is required' },
         400
+      );
+    }
+
+    const authContext = getAuthContext(c);
+    if (!authContext || authContext.userId !== userId) {
+      return c.json(
+        { success: false, error: 'Unauthorized modification of user profile' },
+        403
       );
     }
 
@@ -241,6 +258,14 @@ export async function changePasswordHandler(c: Context) {
       return c.json(
         { success: false, error: 'User ID and new password are required' },
         400
+      );
+    }
+
+    const authContext = getAuthContext(c);
+    if (!authContext || authContext.userId !== userId) {
+      return c.json(
+        { success: false, error: 'Unauthorized attempt to change password' },
+        403
       );
     }
 

--- a/src/worker/routes/auth-routes.ts
+++ b/src/worker/routes/auth-routes.ts
@@ -16,6 +16,7 @@ import {
   requestPasswordResetHandler,
   resetPasswordHandler,
 } from '../handlers/auth';
+import { requireAuth } from '../middleware/auth-middleware';
 
 const authApi = new Hono();
 
@@ -54,23 +55,23 @@ authApi.options('/reset-password', (c) => new Response(null, { status: 204 }));
  */
 
 // Verify token
-authApi.post('/verify', verifyTokenHandler);
+authApi.post('/verify', requireAuth, verifyTokenHandler);
 authApi.options('/verify', (c) => new Response(null, { status: 204 }));
 
 // Get user profile
-authApi.get('/profile/:userId', getUserProfileHandler);
+authApi.get('/profile/:userId', requireAuth, getUserProfileHandler);
 authApi.options('/profile/:userId', (c) => new Response(null, { status: 204 }));
 
 // Update user profile
-authApi.put('/profile/:userId', updateUserProfileHandler);
+authApi.put('/profile/:userId', requireAuth, updateUserProfileHandler);
 authApi.options('/profile/:userId', (c) => new Response(null, { status: 204 }));
 
 // Change password
-authApi.post('/change-password/:userId', changePasswordHandler);
+authApi.post('/change-password/:userId', requireAuth, changePasswordHandler);
 authApi.options('/change-password/:userId', (c) => new Response(null, { status: 204 }));
 
 // Logout
-authApi.post('/logout', logoutHandler);
+authApi.post('/logout', requireAuth, logoutHandler);
 authApi.options('/logout', (c) => new Response(null, { status: 204 }));
 
 export default authApi;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The sensitive user profile endpoints (`GET /profile/:userId`, `PUT /profile/:userId`, and `POST /change-password/:userId`) lacked authentication, and their handlers blindly trusted the URL parameter, allowing anyone to read or modify any user's profile and password.
🎯 Impact: Unauthenticated users or authenticated attackers could perform full account takeovers, steal sensitive user data, or change other users' passwords by directly referencing their User IDs.
🔧 Fix:
1. Applied the `requireAuth` middleware to the sensitive routes in `auth-routes.ts` (as well as to `/verify` and `/logout`).
2. Added authorization logic in `src/worker/handlers/auth.ts` to ensure the requested resource ID strictly matches the authenticated user ID (`authContext.userId !== userId`), throwing a `403 Forbidden` on mismatches.
✅ Verification: Ran linters and tests to ensure no syntax errors or regressions were introduced. Evaluated changes through security code review.

---
*PR created automatically by Jules for task [4483519142106740212](https://jules.google.com/task/4483519142106740212) started by @njtan142*