### PR TITLE
⚡ Bolt: Optimize getConcernStatistics with single-pass aggregation

### DIFF
--- a/src/worker/lib/concern-status-manager.ts
+++ b/src/worker/lib/concern-status-manager.ts
@@ -112,72 +112,102 @@ export class ConcernStatusManagerImpl implements ConcernStatusManager {
     try {
       const concerns = await this.getConcernsByStatus(conversationId);
       
-      // Calculate overall statistics
+      // Calculate overall statistics in a single pass to avoid O(k*N) complexity
       const total = concerns.length;
-      const toBeDone = concerns.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-      const addressed = concerns.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-      const rejected = concerns.filter(c => c.status === ConcernStatus.REJECTED).length;
+      let toBeDone = 0;
+      let addressed = 0;
+      let rejected = 0;
 
-      // Calculate statistics by category
       const byCategory: Record<ConcernCategory, ConcernStatusBreakdown> = {} as Record<ConcernCategory, ConcernStatusBreakdown>;
-      
-      Object.values(ConcernCategory).forEach(category => {
-        const categoryData = concerns.filter(c => c.category === category);
-        const total = categoryData.length;
-        const toBeDone = categoryData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-        const addressed = categoryData.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-        const rejected = categoryData.filter(c => c.status === ConcernStatus.REJECTED).length;
-        byCategory[category] = {
-          status: category as unknown as ConcernStatus, // This is a workaround - category is a ConcernCategory, not ConcernStatus
-          count: total,
-          percentage: total > 0 ? (addressed / total) * 100 : 0,
-          total,
-          toBeDone,
-          addressed,
-          rejected
-        };
-      });
-
-      // Calculate statistics by severity
       const bySeverity: Record<ConcernSeverity, ConcernStatusBreakdown> = {} as Record<ConcernSeverity, ConcernStatusBreakdown>;
       
-      Object.values(ConcernSeverity).forEach(severity => {
-        const severityData = concerns.filter(c => c.severity === severity);
-        const total = severityData.length;
-        const toBeDone = severityData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-        const addressed = severityData.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-        const rejected = severityData.filter(c => c.status === ConcernStatus.REJECTED).length;
-        bySeverity[severity] = {
-          status: severity as unknown as ConcernStatus, // This is a workaround - severity is a ConcernSeverity, not ConcernStatus
-          count: total,
-          percentage: total > 0 ? (addressed / total) * 100 : 0,
-          total,
-          toBeDone,
-          addressed,
-          rejected
+      const concernsByStatus: Record<ConcernStatus, number> = {
+        [ConcernStatus.OPEN]: 0,
+        [ConcernStatus.RESOLVED]: 0,
+        [ConcernStatus.DISMISSED]: 0,
+        [ConcernStatus.ADDRESSED]: 0,
+        [ConcernStatus.REJECTED]: 0,
+        [ConcernStatus.TO_BE_DONE]: 0
+      };
+
+      const concernsByCategory: Record<ConcernCategory, number> = {} as Record<ConcernCategory, number>;
+      const concernsBySeverity: Record<ConcernSeverity, number> = {} as Record<ConcernSeverity, number>;
+
+      // Initialize structures
+      Object.values(ConcernCategory).forEach(category => {
+        concernsByCategory[category] = 0;
+        byCategory[category] = {
+          status: category as unknown as ConcernStatus,
+          count: 0,
+          percentage: 0,
+          total: 0,
+          toBeDone: 0,
+          addressed: 0,
+          rejected: 0
         };
       });
 
-      // Calculate concerns by status
-      const concernsByStatus: Record<ConcernStatus, number> = {
-        [ConcernStatus.OPEN]: concerns.filter(c => c.status === ConcernStatus.OPEN).length,
-        [ConcernStatus.RESOLVED]: concerns.filter(c => c.status === ConcernStatus.RESOLVED).length,
-        [ConcernStatus.DISMISSED]: concerns.filter(c => c.status === ConcernStatus.DISMISSED).length,
-        [ConcernStatus.ADDRESSED]: addressed,
-        [ConcernStatus.REJECTED]: rejected,
-        [ConcernStatus.TO_BE_DONE]: toBeDone
-      };
-
-      // Calculate concerns by category
-      const concernsByCategory: Record<ConcernCategory, number> = {} as Record<ConcernCategory, number>;
-      Object.values(ConcernCategory).forEach(category => {
-        concernsByCategory[category] = concerns.filter(c => c.category === category).length;
+      Object.values(ConcernSeverity).forEach(severity => {
+        concernsBySeverity[severity] = 0;
+        bySeverity[severity] = {
+          status: severity as unknown as ConcernStatus,
+          count: 0,
+          percentage: 0,
+          total: 0,
+          toBeDone: 0,
+          addressed: 0,
+          rejected: 0
+        };
       });
 
-      // Calculate concerns by severity
-      const concernsBySeverity: Record<ConcernSeverity, number> = {} as Record<ConcernSeverity, number>;
+      // Single pass processing
+      concerns.forEach(c => {
+        // Overall status
+        if (c.status === ConcernStatus.TO_BE_DONE) toBeDone++;
+        else if (c.status === ConcernStatus.ADDRESSED) addressed++;
+        else if (c.status === ConcernStatus.REJECTED) rejected++;
+
+        // Status counts
+        if (concernsByStatus[c.status] !== undefined) {
+          concernsByStatus[c.status]++;
+        }
+
+        // Category counts
+        if (c.category) {
+          concernsByCategory[c.category]++;
+          if (byCategory[c.category]) {
+            byCategory[c.category].total!++;
+            byCategory[c.category].count = byCategory[c.category].total;
+            if (c.status === ConcernStatus.TO_BE_DONE) byCategory[c.category].toBeDone!++;
+            else if (c.status === ConcernStatus.ADDRESSED) byCategory[c.category].addressed!++;
+            else if (c.status === ConcernStatus.REJECTED) byCategory[c.category].rejected!++;
+          }
+        }
+
+        // Severity counts
+        if (c.severity) {
+          concernsBySeverity[c.severity]++;
+          if (bySeverity[c.severity]) {
+            bySeverity[c.severity].total!++;
+            bySeverity[c.severity].count = bySeverity[c.severity].total;
+            if (c.status === ConcernStatus.TO_BE_DONE) bySeverity[c.severity].toBeDone!++;
+            else if (c.status === ConcernStatus.ADDRESSED) bySeverity[c.severity].addressed!++;
+            else if (c.status === ConcernStatus.REJECTED) bySeverity[c.severity].rejected!++;
+          }
+        }
+      });
+
+      // Calculate percentages
+      Object.values(ConcernCategory).forEach(category => {
+        if (byCategory[category] && byCategory[category].total! > 0) {
+          byCategory[category].percentage = (byCategory[category].addressed! / byCategory[category].total!) * 100;
+        }
+      });
+
       Object.values(ConcernSeverity).forEach(severity => {
-        concernsBySeverity[severity] = concerns.filter(c => c.severity === severity).length;
+        if (bySeverity[severity] && bySeverity[severity].total! > 0) {
+          bySeverity[severity].percentage = (bySeverity[severity].addressed! / bySeverity[severity].total!) * 100;
+        }
       });
 
       // Calculate resolution rate (simple calculation)


### PR DESCRIPTION
💡 What: Refactored `getConcernStatistics` inside `src/worker/lib/concern-status-manager.ts` to use a single O(N) `.forEach()` traversal instead of 10+ consecutive `.filter().length` array traversals (which resulted in `O(k*N)` runtime).
🎯 Why: Iterating over the same array multiple times within `Object.values(ConcernCategory).forEach` and `Object.values(ConcernSeverity).forEach` loops causes severe and redundant array traversal overhead when processing large lists of proofreading concerns.
📊 Impact: Expected to significantly reduce execution time and computational overhead for rendering proofreading statistics on larger text bodies. Reduces multiple traversals down to just exactly 1.
🔬 Measurement: Verified functionality by executing `npx vitest run src/tests/concern-status-manager.test.ts -t "Statistics Calculation"` ensuring statistics calculations were 100% accurate.

---
*PR created automatically by Jules for task [9312802529152162083](https://jules.google.com/task/9312802529152162083) started by @njtan142*