### PR TITLE
🎨 Palette: Add aria-labels to badge removal buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-02 - Missing aria-labels on badge removal buttons
+**Learning:** Dynamic lists using badges with icon-only close buttons (like 'X' or '×') frequently lack `aria-label` attributes across components (e.g., Reference Form authors/tags, Search Result Sharing emails, Concern List filters). This makes it impossible for screen reader users to understand what item they are removing.
+**Action:** Always ensure an explicit `aria-label` (e.g., `aria-label="Remove [item name]"`) is added to any icon-only button used for removal or clearing within dynamic arrays and badges.

--- a/src/components/ui/concern-list.tsx
+++ b/src/components/ui/concern-list.tsx
@@ -477,6 +477,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => onFilterChange('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear status filter"
                 >
                   ×
                 </button>
@@ -488,6 +489,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => setCategoryFilter('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear category filter"
                 >
                   ×
                 </button>
@@ -499,6 +501,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => setSeverityFilter('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear severity filter"
                 >
                   ×
                 </button>

--- a/src/components/ui/reference-form.tsx
+++ b/src/components/ui/reference-form.tsx
@@ -294,6 +294,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeAuthor(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove author"
                     >
                       <X className="h-3 w-3" />
                     </button>
@@ -466,6 +467,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeTag(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove tag"
                     >
                       <X className="h-3 w-3" />
                     </button>

--- a/src/components/ui/search-result-sharing.tsx
+++ b/src/components/ui/search-result-sharing.tsx
@@ -352,6 +352,7 @@ export const SearchResultSharing: React.FC<SearchResultSharingProps> = ({
                         <button
                           onClick={() => handleRemoveEmail(email)}
                           className="ml-1 hover:text-red-600"
+                          aria-label="Remove email"
                         >
                           <X className="h-3 w-3" />
                         </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only "X" close buttons within dynamic list badges across three components (`reference-form.tsx`, `search-result-sharing.tsx`, `concern-list.tsx`).

🎯 Why: These buttons previously only contained an icon, making them completely inaccessible to screen reader users who would only hear "button" without knowing what item they were removing or what filter they were clearing.

📸 Before/After: N/A (non-visual change)

♿ Accessibility: Ensures that dynamic badge removal actions are fully understandable via screen reader, significantly improving form and list accessibility. Also documented this pattern in `.jules/palette.md` to prevent future regressions.

---
*PR created automatically by Jules for task [13047338315041104776](https://jules.google.com/task/13047338315041104776) started by @njtan142*