### PR TITLE
🎨 Palette: Add dynamic aria-labels to password toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Dynamic Aria-Labels for State Toggles
+**Learning:** Icon-only buttons that toggle states (like password visibility) often miss context-aware accessibility labeling. Screen reader users need to know both the current state and the action that will happen when clicked.
+**Action:** Always implement dynamic `aria-label` attributes on state-toggling icon buttons, rather than static labels. For example, use `aria-label={showPassword ? "Hide password" : "Show password"}` instead of just `"Toggle password visibility"`.

--- a/src/react-app/pages/Login.tsx
+++ b/src/react-app/pages/Login.tsx
@@ -98,6 +98,7 @@ export default function Login() {
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
                   >
                     {showPassword ? (

--- a/src/react-app/pages/Register.tsx
+++ b/src/react-app/pages/Register.tsx
@@ -212,6 +212,7 @@ export default function Register() {
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
                   >
                     {showPassword ? (
@@ -276,6 +277,7 @@ export default function Register() {
                   <button
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
                   >
                     {showConfirmPassword ? (


### PR DESCRIPTION
💡 **What:** Added context-aware `aria-label` attributes to the password visibility toggle (eye icon) buttons in the Login and Register forms.
🎯 **Why:** To improve accessibility for screen reader users. Previously, the buttons were icon-only, meaning screen reader users would not know what the button does or what state it is currently in.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce "Show password" or "Hide password" depending on the current visibility state, instead of just reading out an unlabeled graphic or button.

---
*PR created automatically by Jules for task [12997134935833170506](https://jules.google.com/task/12997134935833170506) started by @njtan142*