### PR TITLE
🎨 Palette: Add ARIA labels to filter clear buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-05 - Add ARIA Labels to Filter Clear Buttons
+**Learning:** Dynamic icon-only buttons for clearing filters (e.g., just rendering '×') often lack `aria-label`s, causing screen readers to misinterpret their context. They must explicitly state what filter is being cleared (e.g., 'Clear status filter').
+**Action:** Always verify that dynamically conditionally rendered clear or remove icon-only buttons include explicit and descriptive `aria-label` attributes.

--- a/src/components/ui/concern-list.tsx
+++ b/src/components/ui/concern-list.tsx
@@ -477,6 +477,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => onFilterChange('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear status filter"
                 >
                   ×
                 </button>
@@ -488,6 +489,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => setCategoryFilter('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear category filter"
                 >
                   ×
                 </button>
@@ -499,6 +501,7 @@ export const ConcernList: React.FC<ConcernListProps> = ({
                 <button
                   onClick={() => setSeverityFilter('all')}
                   className="ml-1 hover:text-red-600"
+                  aria-label="Clear severity filter"
                 >
                   ×
                 </button>


### PR DESCRIPTION
💡 What: Added explicit `aria-label` attributes to the "clear filter" buttons (e.g. `aria-label="Clear status filter"`) in the `ConcernList` component.
🎯 Why: These dynamically conditionally rendered icon-only buttons (displaying an '×') had no text alternative, causing screen readers to misinterpret their context, leaving visually impaired users unsure of what action the button would take.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Ensures that screen readers can now accurately convey the purpose of the filter clearing actions (e.g., "Clear category filter").

---
*PR created automatically by Jules for task [526123454842545046](https://jules.google.com/task/526123454842545046) started by @njtan142*