### PR TITLE
⚡ Bolt: [performance improvement] Optimize concern statistics to single pass

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+
+## 2024-05-24 - Single Pass Optimization over Chained Array Methods
+**Learning:** The codebase previously contained an anti-pattern in statistics aggregation where multiple `.filter(...).length` statements were used inside loops. This caused O(N*M) time complexity as well as high memory allocations for temporary arrays.
+**Action:** When calculating statistics across multiple dimensions (e.g., severity, category, status), always use a single-pass `reduce` or `for...of` loop with pre-initialized accumulator objects to ensure O(N) traversal.

--- a/src/worker/handlers/proofreader-ai.ts
+++ b/src/worker/handlers/proofreader-ai.ts
@@ -574,33 +574,51 @@ function generateSeverityBreakdown(concerns: ProofreadingConcern[]): Record<Conc
  */
 function generateConcernStatistics(concerns: any[]): ConcernStatistics {
   const total = concerns.length;
-  const toBeDone = concerns.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-  const addressed = concerns.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-  const rejected = concerns.filter(c => c.status === ConcernStatus.REJECTED).length;
+  let toBeDone = 0;
+  let addressed = 0;
+  let rejected = 0;
   
   // Generate breakdown by category
   const byCategory = {} as Record<ConcernCategory, any>;
   Object.values(ConcernCategory).forEach(category => {
-    const categoryData = concerns.filter(c => c.category === category);
     byCategory[category] = {
-      total: categoryData.length,
-      toBeDone: categoryData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length,
-      addressed: categoryData.filter(c => c.status === ConcernStatus.ADDRESSED).length,
-      rejected: categoryData.filter(c => c.status === ConcernStatus.REJECTED).length
+      total: 0,
+      toBeDone: 0,
+      addressed: 0,
+      rejected: 0
     };
   });
   
   // Generate breakdown by severity
   const bySeverity = {} as Record<ConcernSeverity, any>;
   Object.values(ConcernSeverity).forEach(severity => {
-    const severityData = concerns.filter(c => c.severity === severity);
     bySeverity[severity] = {
-      total: severityData.length,
-      toBeDone: severityData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length,
-      addressed: severityData.filter(c => c.status === ConcernStatus.ADDRESSED).length,
-      rejected: severityData.filter(c => c.status === ConcernStatus.REJECTED).length
+      total: 0,
+      toBeDone: 0,
+      addressed: 0,
+      rejected: 0
     };
   });
+
+  for (const c of concerns) {
+    if (c.status === ConcernStatus.TO_BE_DONE) toBeDone++;
+    else if (c.status === ConcernStatus.ADDRESSED) addressed++;
+    else if (c.status === ConcernStatus.REJECTED) rejected++;
+
+    if (c.category in byCategory) {
+      byCategory[c.category as ConcernCategory].total++;
+      if (c.status === ConcernStatus.TO_BE_DONE) byCategory[c.category as ConcernCategory].toBeDone++;
+      else if (c.status === ConcernStatus.ADDRESSED) byCategory[c.category as ConcernCategory].addressed++;
+      else if (c.status === ConcernStatus.REJECTED) byCategory[c.category as ConcernCategory].rejected++;
+    }
+
+    if (c.severity in bySeverity) {
+      bySeverity[c.severity as ConcernSeverity].total++;
+      if (c.status === ConcernStatus.TO_BE_DONE) bySeverity[c.severity as ConcernSeverity].toBeDone++;
+      else if (c.status === ConcernStatus.ADDRESSED) bySeverity[c.severity as ConcernSeverity].addressed++;
+      else if (c.status === ConcernStatus.REJECTED) bySeverity[c.severity as ConcernSeverity].rejected++;
+    }
+  }
   
   return {
     totalConcerns: total,

--- a/src/worker/lib/concern-status-manager.ts
+++ b/src/worker/lib/concern-status-manager.ts
@@ -112,72 +112,92 @@ export class ConcernStatusManagerImpl implements ConcernStatusManager {
     try {
       const concerns = await this.getConcernsByStatus(conversationId);
       
-      // Calculate overall statistics
       const total = concerns.length;
-      const toBeDone = concerns.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-      const addressed = concerns.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-      const rejected = concerns.filter(c => c.status === ConcernStatus.REJECTED).length;
+      let toBeDone = 0;
+      let addressed = 0;
+      let rejected = 0;
 
-      // Calculate statistics by category
-      const byCategory: Record<ConcernCategory, ConcernStatusBreakdown> = {} as Record<ConcernCategory, ConcernStatusBreakdown>;
+      // Initialize structures
+      const concernsByStatus = {
+        [ConcernStatus.OPEN]: 0,
+        [ConcernStatus.RESOLVED]: 0,
+        [ConcernStatus.DISMISSED]: 0,
+        [ConcernStatus.ADDRESSED]: 0,
+        [ConcernStatus.REJECTED]: 0,
+        [ConcernStatus.TO_BE_DONE]: 0
+      } as Record<ConcernStatus, number>;
+
+      const concernsByCategory = {} as Record<ConcernCategory, number>;
+      const byCategory = {} as Record<ConcernCategory, ConcernStatusBreakdown>;
       
       Object.values(ConcernCategory).forEach(category => {
-        const categoryData = concerns.filter(c => c.category === category);
-        const total = categoryData.length;
-        const toBeDone = categoryData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-        const addressed = categoryData.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-        const rejected = categoryData.filter(c => c.status === ConcernStatus.REJECTED).length;
+        concernsByCategory[category] = 0;
         byCategory[category] = {
           status: category as unknown as ConcernStatus, // This is a workaround - category is a ConcernCategory, not ConcernStatus
-          count: total,
-          percentage: total > 0 ? (addressed / total) * 100 : 0,
-          total,
-          toBeDone,
-          addressed,
-          rejected
+          count: 0,
+          percentage: 0,
+          total: 0,
+          toBeDone: 0,
+          addressed: 0,
+          rejected: 0
         };
       });
 
-      // Calculate statistics by severity
-      const bySeverity: Record<ConcernSeverity, ConcernStatusBreakdown> = {} as Record<ConcernSeverity, ConcernStatusBreakdown>;
+      const concernsBySeverity = {} as Record<ConcernSeverity, number>;
+      const bySeverity = {} as Record<ConcernSeverity, ConcernStatusBreakdown>;
       
       Object.values(ConcernSeverity).forEach(severity => {
-        const severityData = concerns.filter(c => c.severity === severity);
-        const total = severityData.length;
-        const toBeDone = severityData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-        const addressed = severityData.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-        const rejected = severityData.filter(c => c.status === ConcernStatus.REJECTED).length;
+        concernsBySeverity[severity] = 0;
         bySeverity[severity] = {
           status: severity as unknown as ConcernStatus, // This is a workaround - severity is a ConcernSeverity, not ConcernStatus
-          count: total,
-          percentage: total > 0 ? (addressed / total) * 100 : 0,
-          total,
-          toBeDone,
-          addressed,
-          rejected
+          count: 0,
+          percentage: 0,
+          total: 0,
+          toBeDone: 0,
+          addressed: 0,
+          rejected: 0
         };
       });
 
-      // Calculate concerns by status
-      const concernsByStatus: Record<ConcernStatus, number> = {
-        [ConcernStatus.OPEN]: concerns.filter(c => c.status === ConcernStatus.OPEN).length,
-        [ConcernStatus.RESOLVED]: concerns.filter(c => c.status === ConcernStatus.RESOLVED).length,
-        [ConcernStatus.DISMISSED]: concerns.filter(c => c.status === ConcernStatus.DISMISSED).length,
-        [ConcernStatus.ADDRESSED]: addressed,
-        [ConcernStatus.REJECTED]: rejected,
-        [ConcernStatus.TO_BE_DONE]: toBeDone
-      };
+      // Single pass aggregation
+      for (const c of concerns) {
+        // Overall
+        if (c.status === ConcernStatus.TO_BE_DONE) toBeDone++;
+        else if (c.status === ConcernStatus.ADDRESSED) addressed++;
+        else if (c.status === ConcernStatus.REJECTED) rejected++;
 
-      // Calculate concerns by category
-      const concernsByCategory: Record<ConcernCategory, number> = {} as Record<ConcernCategory, number>;
-      Object.values(ConcernCategory).forEach(category => {
-        concernsByCategory[category] = concerns.filter(c => c.category === category).length;
+        // Status mapping
+        if (c.status in concernsByStatus) {
+          concernsByStatus[c.status as ConcernStatus]++;
+        }
+
+        // Category mapping
+        if (c.category in concernsByCategory) {
+          concernsByCategory[c.category]++;
+          byCategory[c.category].count++;
+          byCategory[c.category].total!++;
+          if (c.status === ConcernStatus.TO_BE_DONE) byCategory[c.category].toBeDone!++;
+          else if (c.status === ConcernStatus.ADDRESSED) byCategory[c.category].addressed!++;
+          else if (c.status === ConcernStatus.REJECTED) byCategory[c.category].rejected!++;
+        }
+
+        // Severity mapping
+        if (c.severity in concernsBySeverity) {
+          concernsBySeverity[c.severity]++;
+          bySeverity[c.severity].count++;
+          bySeverity[c.severity].total!++;
+          if (c.status === ConcernStatus.TO_BE_DONE) bySeverity[c.severity].toBeDone!++;
+          else if (c.status === ConcernStatus.ADDRESSED) bySeverity[c.severity].addressed!++;
+          else if (c.status === ConcernStatus.REJECTED) bySeverity[c.severity].rejected!++;
+        }
+      }
+
+      // Calculate percentages
+      Object.values(byCategory).forEach(cat => {
+        cat.percentage = cat.total! > 0 ? (cat.addressed! / cat.total!) * 100 : 0;
       });
-
-      // Calculate concerns by severity
-      const concernsBySeverity: Record<ConcernSeverity, number> = {} as Record<ConcernSeverity, number>;
-      Object.values(ConcernSeverity).forEach(severity => {
-        concernsBySeverity[severity] = concerns.filter(c => c.severity === severity).length;
+      Object.values(bySeverity).forEach(sev => {
+        sev.percentage = sev.total! > 0 ? (sev.addressed! / sev.total!) * 100 : 0;
       });
 
       // Calculate resolution rate (simple calculation)


### PR DESCRIPTION
💡 What: Refactored statistics aggregation in `concern-status-manager.ts` and `proofreader-ai.ts` to use a single O(N) traversal over the `concerns` array rather than repeatedly evaluating `.filter(...).length` for every category, severity, and status.
🎯 Why: In large documents with many concerns, iterating over the array up to ~30 times generated severe O(N*M) time complexity and unnecessary array allocation memory pressure.
📊 Impact: Transforms statistics aggregation from O(N*M) to pure O(N), drastically reducing both time spent in these loops and garbage collection pauses from throwing away temporary intermediate `.filter()` arrays.
🔬 Measurement: Verified through existing `concern-status-manager.test.ts` and `proofreader-ai.test.ts` to guarantee logic remains identical while saving CPU cycles.

---
*PR created automatically by Jules for task [10823484333055956335](https://jules.google.com/task/10823484333055956335) started by @njtan142*