### PR TITLE
⚡ Bolt: [performance improvement] Optimize getConcernStatistics array traversals

### DIFF
--- a/src/worker/lib/concern-status-manager.ts
+++ b/src/worker/lib/concern-status-manager.ts
@@ -112,72 +112,88 @@ export class ConcernStatusManagerImpl implements ConcernStatusManager {
     try {
       const concerns = await this.getConcernsByStatus(conversationId);
       
-      // Calculate overall statistics
       const total = concerns.length;
-      const toBeDone = concerns.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-      const addressed = concerns.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-      const rejected = concerns.filter(c => c.status === ConcernStatus.REJECTED).length;
+      let toBeDone = 0;
+      let addressed = 0;
+      let rejected = 0;
 
-      // Calculate statistics by category
       const byCategory: Record<ConcernCategory, ConcernStatusBreakdown> = {} as Record<ConcernCategory, ConcernStatusBreakdown>;
-      
-      Object.values(ConcernCategory).forEach(category => {
-        const categoryData = concerns.filter(c => c.category === category);
-        const total = categoryData.length;
-        const toBeDone = categoryData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-        const addressed = categoryData.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-        const rejected = categoryData.filter(c => c.status === ConcernStatus.REJECTED).length;
-        byCategory[category] = {
-          status: category as unknown as ConcernStatus, // This is a workaround - category is a ConcernCategory, not ConcernStatus
-          count: total,
-          percentage: total > 0 ? (addressed / total) * 100 : 0,
-          total,
-          toBeDone,
-          addressed,
-          rejected
-        };
-      });
-
-      // Calculate statistics by severity
-      const bySeverity: Record<ConcernSeverity, ConcernStatusBreakdown> = {} as Record<ConcernSeverity, ConcernStatusBreakdown>;
-      
-      Object.values(ConcernSeverity).forEach(severity => {
-        const severityData = concerns.filter(c => c.severity === severity);
-        const total = severityData.length;
-        const toBeDone = severityData.filter(c => c.status === ConcernStatus.TO_BE_DONE).length;
-        const addressed = severityData.filter(c => c.status === ConcernStatus.ADDRESSED).length;
-        const rejected = severityData.filter(c => c.status === ConcernStatus.REJECTED).length;
-        bySeverity[severity] = {
-          status: severity as unknown as ConcernStatus, // This is a workaround - severity is a ConcernSeverity, not ConcernStatus
-          count: total,
-          percentage: total > 0 ? (addressed / total) * 100 : 0,
-          total,
-          toBeDone,
-          addressed,
-          rejected
-        };
-      });
-
-      // Calculate concerns by status
-      const concernsByStatus: Record<ConcernStatus, number> = {
-        [ConcernStatus.OPEN]: concerns.filter(c => c.status === ConcernStatus.OPEN).length,
-        [ConcernStatus.RESOLVED]: concerns.filter(c => c.status === ConcernStatus.RESOLVED).length,
-        [ConcernStatus.DISMISSED]: concerns.filter(c => c.status === ConcernStatus.DISMISSED).length,
-        [ConcernStatus.ADDRESSED]: addressed,
-        [ConcernStatus.REJECTED]: rejected,
-        [ConcernStatus.TO_BE_DONE]: toBeDone
-      };
-
-      // Calculate concerns by category
       const concernsByCategory: Record<ConcernCategory, number> = {} as Record<ConcernCategory, number>;
       Object.values(ConcernCategory).forEach(category => {
-        concernsByCategory[category] = concerns.filter(c => c.category === category).length;
+        concernsByCategory[category] = 0;
+        byCategory[category] = {
+          status: category as unknown as ConcernStatus,
+          count: 0,
+          percentage: 0,
+          total: 0,
+          toBeDone: 0,
+          addressed: 0,
+          rejected: 0
+        };
       });
 
-      // Calculate concerns by severity
+      const bySeverity: Record<ConcernSeverity, ConcernStatusBreakdown> = {} as Record<ConcernSeverity, ConcernStatusBreakdown>;
       const concernsBySeverity: Record<ConcernSeverity, number> = {} as Record<ConcernSeverity, number>;
       Object.values(ConcernSeverity).forEach(severity => {
-        concernsBySeverity[severity] = concerns.filter(c => c.severity === severity).length;
+        concernsBySeverity[severity] = 0;
+        bySeverity[severity] = {
+          status: severity as unknown as ConcernStatus,
+          count: 0,
+          percentage: 0,
+          total: 0,
+          toBeDone: 0,
+          addressed: 0,
+          rejected: 0
+        };
+      });
+
+      const concernsByStatus: Record<ConcernStatus, number> = {
+        [ConcernStatus.OPEN]: 0,
+        [ConcernStatus.RESOLVED]: 0,
+        [ConcernStatus.DISMISSED]: 0,
+        [ConcernStatus.ADDRESSED]: 0,
+        [ConcernStatus.REJECTED]: 0,
+        [ConcernStatus.TO_BE_DONE]: 0
+      };
+
+      // Single pass aggregation to avoid O(N*M) filters
+      concerns.forEach(c => {
+        if (c.status === ConcernStatus.TO_BE_DONE) toBeDone++;
+        if (c.status === ConcernStatus.ADDRESSED) addressed++;
+        if (c.status === ConcernStatus.REJECTED) rejected++;
+
+        if (c.status in concernsByStatus) {
+          concernsByStatus[c.status]++;
+        }
+
+        if (c.category) {
+          concernsByCategory[c.category]++;
+          byCategory[c.category].count++;
+          byCategory[c.category].total++;
+          if (c.status === ConcernStatus.TO_BE_DONE) byCategory[c.category].toBeDone++;
+          if (c.status === ConcernStatus.ADDRESSED) byCategory[c.category].addressed++;
+          if (c.status === ConcernStatus.REJECTED) byCategory[c.category].rejected++;
+        }
+
+        if (c.severity) {
+          concernsBySeverity[c.severity]++;
+          bySeverity[c.severity].count++;
+          bySeverity[c.severity].total++;
+          if (c.status === ConcernStatus.TO_BE_DONE) bySeverity[c.severity].toBeDone++;
+          if (c.status === ConcernStatus.ADDRESSED) bySeverity[c.severity].addressed++;
+          if (c.status === ConcernStatus.REJECTED) bySeverity[c.severity].rejected++;
+        }
+      });
+
+      // Calculate percentages post-aggregation
+      Object.values(ConcernCategory).forEach(category => {
+        const cat = byCategory[category];
+        cat.percentage = cat.total > 0 ? (cat.addressed / cat.total) * 100 : 0;
+      });
+
+      Object.values(ConcernSeverity).forEach(severity => {
+        const sev = bySeverity[severity];
+        sev.percentage = sev.total > 0 ? (sev.addressed / sev.total) * 100 : 0;
       });
 
       // Calculate resolution rate (simple calculation)


### PR DESCRIPTION
💡 **What:** Refactored `getConcernStatistics` in `src/worker/lib/concern-status-manager.ts` to use a single O(N) pass traversal instead of multiple `.filter().length` calls.

🎯 **Why:** The previous logic looped through the `concerns` array repeatedly (O(N*M) time complexity) to filter status conditions over each `ConcernCategory` and `ConcernSeverity`, and calculate global status arrays. Consolidating this significantly reduces redundant processing.

📊 **Impact:** Reduces redundant iterations from dozens per request to exactly one single pass over the array per request. Should yield minor CPU reduction and latency improvement, particularly in conversations heavily populated with hundreds of `concerns`.

🔬 **Measurement:** Code review / testing verified output stats match exactly. Wait times to retrieve large `/api/proofreader/concerns/:id/statistics` responses will trend downward.

---
*PR created automatically by Jules for task [14958854246963808878](https://jules.google.com/task/14958854246963808878) started by @njtan142*