### PR TITLE
🎨 Palette: Add dynamic aria-labels to password visibility toggles

### DIFF
--- a/src/react-app/pages/Login.tsx
+++ b/src/react-app/pages/Login.tsx
@@ -98,6 +98,7 @@ export default function Login() {
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
                   >
                     {showPassword ? (

--- a/src/react-app/pages/Register.tsx
+++ b/src/react-app/pages/Register.tsx
@@ -212,6 +212,7 @@ export default function Register() {
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
                   >
                     {showPassword ? (
@@ -276,6 +277,7 @@ export default function Register() {
                   <button
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    aria-label={showConfirmPassword ? "Hide password" : "Show password"}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
                   >
                     {showConfirmPassword ? (


### PR DESCRIPTION
**What:** Added dynamic `aria-label` attributes to the password visibility toggle buttons in both `Login.tsx` and `Register.tsx`.

**Why:** The eye icon buttons used to toggle password visibility lacked `aria-label` attributes, making them inaccessible to screen reader users who would not know what the buttons do or their current state.

**Accessibility:** Added dynamic `aria-label`s that correctly reflect the current state (e.g., "Show password" vs "Hide password").

Before:
`<button><Eye/></button>`

After:
`<button aria-label="Show password"><Eye/></button>`

---
*PR created automatically by Jules for task [3831393412431226764](https://jules.google.com/task/3831393412431226764) started by @njtan142*