### PR TITLE
⚡ Bolt: [performance improvement] Replace N+1 Promise.all map query with ROW_NUMBER

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+
+## 2024-03-24 - Resolve N+1 Bottleneck in Query Performance Analytics
+**Learning:** Found a major N+1 database query pattern in `src/worker/lib/enhanced-search-history-manager.ts` where fetching top search results for each query involved mapping over a `Promise.all` set of queries for individual `search_query` entries. This scales poorly in Cloudflare D1/SQLite.
+**Action:** When resolving N+1 database query bottlenecks within Cloudflare D1 / SQLite (such as those occurring inside `Promise.all` `.map` loops), optimize by executing a single parameterized query utilizing window functions like `ROW_NUMBER() OVER(PARTITION BY ...)` to group and rank results, and process the results into a JavaScript `Map` memory cache for association.

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -315,43 +315,58 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
       `;
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
+      const rows = result.results || [];
+      if (rows.length === 0) return [];
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
-            ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+      const searchQueries = rows.map((r: any) => r.search_query);
+      const queryPlaceholders = searchQueries.map(() => '?').join(',');
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      // Get top results for each query using a single query with window functions (Bolt Optimization)
+      let topResultsQuery = `
+        SELECT * FROM (
+          SELECT sr.result_title, sr.relevance_score, sr.added_to_library, ss.search_query,
+                 ROW_NUMBER() OVER(PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.search_query IN (${queryPlaceholders}) AND ss.user_id = ?
+          ${conversationId ? 'AND ss.conversation_id = ?' : ''}
+        )
+        WHERE rn <= 3
+        ORDER BY search_query, rn ASC
+      `;
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      const topResultsParams = [...searchQueries, userId];
+      if (conversationId) {
+        topResultsParams.push(conversationId);
+      }
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
+
+      // Group results by search_query
+      const topResultsMap = new Map<string, Array<{title: string, relevanceScore: number, addedToLibrary: boolean}>>();
+
+      (topResultsResult.results || []).forEach((r: any) => {
+        if (!topResultsMap.has(r.search_query)) {
+          topResultsMap.set(r.search_query, []);
+        }
+        topResultsMap.get(r.search_query)!.push({
+          title: r.result_title,
+          relevanceScore: r.relevance_score,
+          addedToLibrary: r.added_to_library
+        });
+      });
+
+      const queryAnalytics = rows.map((row: any) => {
+        return {
+          query: row.search_query,
+          searchCount: row.search_count,
+          averageResults: row.avg_results || 0,
+          successRate: row.success_rate || 0,
+          averageProcessingTime: row.avg_processing_time || 0,
+          lastUsed: new Date(row.last_used),
+          topResults: topResultsMap.get(row.search_query) || []
+        };
+      });
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
💡 **What:** Replaced the `Promise.all` `.map` database lookup bottleneck in `EnhancedSearchHistoryManager.getQueryPerformanceAnalytics` with a single parameterized query utilizing the `ROW_NUMBER() OVER` window function and grouped Map execution.
🎯 **Why:** To prevent N+1 database queries when fetching the top three search results for up to 20 grouped search history queries. The previous code mapped each search query and sequentially awaited top results over individual round-trips.
📊 **Impact:** Reduces database calls for `getQueryPerformanceAnalytics` from 1 + 20 queries down to exactly 2 queries. The performance scales flat O(1) in networking operations regardless of history complexity instead of O(N).
🔬 **Measurement:** Execute `bun test src/worker/lib/` to confirm unit tests pass. Observe D1 worker metric logs to witness a decrease in active concurrent query counts.

---
*PR created automatically by Jules for task [16724210070478215758](https://jules.google.com/task/16724210070478215758) started by @njtan142*