### PR TITLE
🎨 Palette: Add ARIA labels to attachment menu edit buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Missing ARIA Labels in Conditionally Rendered Dynamic State Icon Buttons
+**Learning:** Icon-only buttons that are conditionally rendered based on UI state (e.g., toggling between default "Edit"/"Regenerate" states and active "Save"/"Cancel" edit modes) are highly prone to missing `aria-label` attributes. Developers often overlook accessibility for transient or dynamic inline editing states compared to permanent UI fixtures.
+**Action:** Always audit inline editing components and ensure that each branch of a conditionally rendered icon-only button explicitly defines a context-aware `aria-label` attribute (e.g., `aria-label="Save title edit"` vs `aria-label="Edit title"`).

--- a/src/components/ui/attachment-menu.tsx
+++ b/src/components/ui/attachment-menu.tsx
@@ -371,6 +371,7 @@ function IdeaSelectorDialog({
                           className="h-7 w-7"
                           onClick={(e) => handleSaveEdit(idea, e)}
                           disabled={isUpdating}
+                          aria-label="Save title edit"
                         >
                           {isUpdating ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
@@ -384,6 +385,7 @@ function IdeaSelectorDialog({
                           className="h-7 w-7"
                           onClick={handleCancelEdit}
                           disabled={isUpdating}
+                          aria-label="Cancel title edit"
                         >
                           <X className="h-4 w-4 text-destructive" />
                         </Button>
@@ -405,6 +407,7 @@ function IdeaSelectorDialog({
                           className="h-6 w-6 shrink-0"
                           onClick={(e) => handleStartEdit(idea, e)}
                           title="Edit title"
+                          aria-label="Edit title"
                         >
                           <Pencil className="h-3 w-3" />
                         </Button>
@@ -415,6 +418,7 @@ function IdeaSelectorDialog({
                           onClick={(e) => handleRegenerateTitle(idea, e)}
                           disabled={regeneratingId === idea.id || !idea.description}
                           title="Regenerate title with AI"
+                          aria-label="Regenerate title with AI"
                         >
                           {regeneratingId === idea.id ? (
                             <Loader2 className="h-3 w-3 animate-spin" />


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes ("Save title edit", "Cancel title edit", "Edit title", "Regenerate title with AI") to the conditional icon-only buttons within the idea item row in the `AttachmentMenu` component.
🎯 **Why**: Conditionally rendered icon-only buttons lack accessible names for screen readers, making it difficult for users utilizing assistive technologies to understand the purpose of these dynamic inline-editing actions.
📸 **Before/After**: Visually identical; screen-reader accessible names added.
♿ **Accessibility**: Provides contextual meaning to dynamic icon buttons during inline title modifications.

---
*PR created automatically by Jules for task [8682413467973921607](https://jules.google.com/task/8682413467973921607) started by @njtan142*