### PR TITLE
⚡ Bolt: Eliminate N+1 query bottleneck in getQueryPerformanceAnalytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+## 2024-05-18 - Eliminating N+1 database queries with Window Functions
+**Learning:** In Cloudflare D1 / SQLite environments, executing sequential database queries within a \`Promise.all(...\map())\` loop introduces a significant N+1 performance bottleneck that blocks backend thread resolution.
+**Action:** When gathering nested top-N relationships for a set of items, always utilize window functions like \`ROW_NUMBER() OVER(PARTITION BY ...)\` to group, rank, and fetch results in a single consolidated database query, matching by a grouped identifier like \`IN (?)\`.

--- a/src/tests/enhanced-search-history-manager.test.ts
+++ b/src/tests/enhanced-search-history-manager.test.ts
@@ -339,6 +339,7 @@ describe('EnhancedSearchHistoryManager', () => {
 
       const mockTopResults = [
         {
+          search_query: 'machine learning',
           result_title: 'Deep Learning for NLP',
           relevance_score: 0.95,
           added_to_library: true
@@ -673,13 +674,28 @@ describe('EnhancedSearchHistoryManager', () => {
           }
         ];
 
+        // Consolidated mock top results combining all queries
         const mockTopResults = [
           {
+            search_query: 'machine learning research',
             result_title: 'Advanced ML Techniques',
             relevance_score: 0.92,
             added_to_library: true
           },
           {
+            search_query: 'machine learning research',
+            result_title: 'ML in Healthcare',
+            relevance_score: 0.88,
+            added_to_library: false
+          },
+          {
+            search_query: 'deep learning applications',
+            result_title: 'Advanced ML Techniques',
+            relevance_score: 0.92,
+            added_to_library: true
+          },
+          {
+            search_query: 'deep learning applications',
             result_title: 'ML in Healthcare',
             relevance_score: 0.88,
             added_to_library: false
@@ -688,7 +704,6 @@ describe('EnhancedSearchHistoryManager', () => {
 
         mockPrepare.all
           .mockResolvedValueOnce({ results: mockPerformanceData })
-          .mockResolvedValueOnce({ results: mockTopResults })
           .mockResolvedValueOnce({ results: mockTopResults });
 
         const analytics = await manager.getQueryPerformanceAnalytics('user-1', 'conv-1', 30);

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -316,42 +316,58 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
-            ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+      const rows = result.results || [];
+      if (rows.length === 0) return [];
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      const searchQueries = rows.map((r: any) => r.search_query);
+      const queryPlaceholders = searchQueries.map(() => '?').join(',');
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      // Get top results for all queries in a single window function query
+      const topResultsQuery = `
+        WITH RankedResults AS (
+          SELECT
+            ss.search_query,
+            sr.result_title,
+            sr.relevance_score,
+            sr.added_to_library,
+            ROW_NUMBER() OVER(PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.search_query IN (${queryPlaceholders}) AND ss.user_id = ?
+          ${conversationId ? 'AND ss.conversation_id = ?' : ''}
+        )
+        SELECT * FROM RankedResults WHERE rn <= 3
+      `;
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      const topResultsParams = [...searchQueries, userId];
+      if (conversationId) {
+        topResultsParams.push(conversationId);
+      }
+
+      const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
+
+      // Group results by query
+      const resultsByQuery = new Map<string, Array<any>>();
+      (topResultsResult.results || []).forEach((r: any) => {
+        if (!resultsByQuery.has(r.search_query)) {
+          resultsByQuery.set(r.search_query, []);
+        }
+        resultsByQuery.get(r.search_query)!.push({
+          title: r.result_title,
+          relevanceScore: r.relevance_score,
+          addedToLibrary: r.added_to_library
+        });
+      });
+
+      const queryAnalytics = rows.map((row: any) => ({
+        query: row.search_query,
+        searchCount: row.search_count,
+        averageResults: row.avg_results || 0,
+        successRate: row.success_rate || 0,
+        averageProcessingTime: row.avg_processing_time || 0,
+        lastUsed: new Date(row.last_used),
+        topResults: resultsByQuery.get(row.search_query) || []
+      }));
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
💡 What: Replaced sequential `.map(async () => DB.prepare().all())` loops with a single consolidated query using `ROW_NUMBER() OVER(PARTITION BY ss.search_query)` to group and fetch the top 3 nested results for multiple search queries simultaneously.
🎯 Why: Iterating over queries to execute database commands introduces a severe N+1 bottleneck, keeping the backend main thread busy and leading to potential latency and concurrent request limits in the Cloudflare Worker architecture.
📊 Impact: Consolidates N separate database queries into 1, eliminating the N+1 latency bottleneck entirely and preventing parallel query storms to Cloudflare D1.
🔬 Measurement: Verify by monitoring the Cloudflare D1 query volume drop or running the unit tests using `bun test src/tests/enhanced-search-history-manager.test.ts` to ensure query analytics still correctly calculate the `topResults` grouping.

---
*PR created automatically by Jules for task [11324656912169696635](https://jules.google.com/task/11324656912169696635) started by @njtan142*