### PR TITLE
🎨 Palette: Add dynamic ARIA labels to password toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-04-10 - Dynamic ARIA labels for state-toggling icon buttons
+**Learning:** Icon-only buttons that toggle state (like password visibility toggles using Eye/EyeOff icons) frequently lack ARIA labels. When they do have them, static labels are insufficient. Screen readers need dynamic labels that reflect the current state to properly understand the action they will perform.
+**Action:** Always implement dynamic `aria-label` attributes that use a ternary operator to reflect the current state (e.g., `aria-label={showPassword ? 'Hide password' : 'Show password'}`) for state-toggling icon buttons, rather than just static labels.

--- a/src/react-app/pages/Login.tsx
+++ b/src/react-app/pages/Login.tsx
@@ -99,6 +99,7 @@ export default function Login() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />

--- a/src/react-app/pages/Register.tsx
+++ b/src/react-app/pages/Register.tsx
@@ -213,6 +213,7 @@ export default function Register() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />
@@ -277,6 +278,7 @@ export default function Register() {
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
                   >
                     {showConfirmPassword ? (
                       <EyeOff className="h-4 w-4" />


### PR DESCRIPTION
💡 **What**: Added dynamic `aria-label` attributes to the password visibility toggle buttons (Eye/EyeOff icons) in both the `Login.tsx` and `Register.tsx` pages. The labels explicitly state whether the action will "Show password" or "Hide password" based on the current component state.
🎯 **Why**: Previously, these icon-only buttons did not have any `aria-label` attributes, making them inaccessible and unintuitive for screen reader users, who would not know what action clicking the button would perform.
♿ **Accessibility**: Significant improvement for screen reader accessibility on core authentication pages by ensuring critical interactive state-toggling elements are properly labeled with their dynamic action.

---
*PR created automatically by Jules for task [14548043176286512312](https://jules.google.com/task/14548043176286512312) started by @njtan142*