### PR TITLE
🎨 Palette: Add dynamic ARIA labels to password visibility toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Dynamic ARIA Labels for State-Toggling Icons
+**Learning:** Icon-only buttons that toggle states (like password visibility toggles using Eye/EyeOff icons) are often missing `aria-label`s. Screen readers need these labels to change dynamically to reflect both the current state and the action the button performs, not just a static label.
+**Action:** Always implement dynamic `aria-label` attributes for state-toggling icon-only buttons that reflect the current state and action (e.g., `aria-label={showPassword ? 'Hide password' : 'Show password'}`) to ensure full accessibility.

--- a/src/react-app/pages/Login.tsx
+++ b/src/react-app/pages/Login.tsx
@@ -99,6 +99,7 @@ export default function Login() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />

--- a/src/react-app/pages/Register.tsx
+++ b/src/react-app/pages/Register.tsx
@@ -213,6 +213,7 @@ export default function Register() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />
@@ -277,6 +278,7 @@ export default function Register() {
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showConfirmPassword ? 'Hide confirm password' : 'Show confirm password'}
                   >
                     {showConfirmPassword ? (
                       <EyeOff className="h-4 w-4" />


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` attributes to the password visibility toggle buttons in the Login and Register components. The labels update dynamically (e.g., 'Show password' vs 'Hide password') based on the current component state. Also created a journal entry in `.jules/palette.md` to document this pattern.
🎯 **Why:** Icon-only buttons that toggle state are entirely inaccessible to screen readers without proper labels. Furthermore, a static label is insufficient; the label must reflect the *action* that will occur when the button is pressed next.
♿ **Accessibility:** This directly addresses a WCAG conformance issue by ensuring state-changing icon buttons have clear, dynamic programmatic names.

---
*PR created automatically by Jules for task [8232541819516235866](https://jules.google.com/task/8232541819516235866) started by @njtan142*