### PR TITLE
⚡ Bolt: Fix N+1 query bottleneck in getQueryPerformanceAnalytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+## 2025-04-12 - N+1 Query Fix using SQLite Window Functions
+**Learning:** Cloudflare D1 / SQLite often execute loops containing `DB.prepare().all()` sequentially (e.g. inside `Promise.all` + `map`), causing severe N+1 bottlenecks.
+**Action:** Replace `Promise.all` `.map` database calls over collections with a single batched SQL query using `IN (...)` and a window function like `ROW_NUMBER() OVER(PARTITION BY ...)` to fetch and group top items per related row safely and in one roundtrip. Always explicitly set `ORDER BY` to maintain output predictability.

--- a/src/tests/enhanced-search-history-manager.test.ts
+++ b/src/tests/enhanced-search-history-manager.test.ts
@@ -341,7 +341,8 @@ describe('EnhancedSearchHistoryManager', () => {
         {
           result_title: 'Deep Learning for NLP',
           relevance_score: 0.95,
-          added_to_library: true
+          added_to_library: true,
+          search_query: 'machine learning'
         }
       ];
 
@@ -677,12 +678,14 @@ describe('EnhancedSearchHistoryManager', () => {
           {
             result_title: 'Advanced ML Techniques',
             relevance_score: 0.92,
-            added_to_library: true
+            added_to_library: true,
+            search_query: 'machine learning research'
           },
           {
             result_title: 'ML in Healthcare',
             relevance_score: 0.88,
-            added_to_library: false
+            added_to_library: false,
+            search_query: 'machine learning research'
           }
         ];
 

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -316,42 +316,56 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
-            ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+      if (!result.results || result.results.length === 0) {
+        return [];
+      }
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      // Optimize N+1 query: fetch all top results for these queries in a single batched query
+      const searchQueries = result.results.map((r: any) => r.search_query);
+      const placeholders = searchQueries.map(() => '?').join(',');
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      const topResultsQuery = `
+        SELECT * FROM (
+          SELECT sr.result_title, sr.relevance_score, sr.added_to_library, ss.search_query,
+                 ROW_NUMBER() OVER(PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.search_query IN (${placeholders}) AND ss.user_id = ?
+          ${conversationId ? 'AND ss.conversation_id = ?' : ''}
+        )
+        WHERE rn <= 3
+        ORDER BY search_query, rn ASC
+      `;
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      const topResultsParams = [...searchQueries, userId];
+      if (conversationId) {
+        topResultsParams.push(conversationId);
+      }
+
+      const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
+
+      // Group top results by query
+      const topResultsByQuery = (topResultsResult.results || []).reduce((acc: any, row: any) => {
+        if (!acc[row.search_query]) acc[row.search_query] = [];
+        acc[row.search_query].push({
+          title: row.result_title,
+          relevanceScore: row.relevance_score,
+          addedToLibrary: row.added_to_library
+        });
+        return acc;
+      }, {});
+
+      const queryAnalytics = result.results.map((row: any) => {
+        return {
+          query: row.search_query,
+          searchCount: row.search_count,
+          averageResults: row.avg_results || 0,
+          successRate: row.success_rate || 0,
+          averageProcessingTime: row.avg_processing_time || 0,
+          lastUsed: new Date(row.last_used),
+          topResults: topResultsByQuery[row.search_query] || []
+        };
+      });
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
💡 What: Implemented a batched SQL query using `ROW_NUMBER() OVER(PARTITION BY ...)` to replace an N+1 DB loop in `EnhancedSearchHistoryManager.getQueryPerformanceAnalytics`.
🎯 Why: Cloudflare D1/SQLite doesn't handle N+1 query loops well, causing severe latency inside `Promise.all` + `.map`. This fetch approach allows grabbing top N related items efficiently.
📊 Impact: Reduces database calls from O(n) to O(1) for this operation. Drastically reduces compute time.
🔬 Measurement: Verify using `bun test src/tests/enhanced-search-history-manager.test.ts`. Watch for a successful run or timing improvements against the original implementation.

---
*PR created automatically by Jules for task [1110562975075531857](https://jules.google.com/task/1110562975075531857) started by @njtan142*