### PR TITLE
🎨 Palette: Add dynamic ARIA labels to password visibility toggles

### DIFF
--- a/src/react-app/pages/Login.tsx
+++ b/src/react-app/pages/Login.tsx
@@ -99,6 +99,7 @@ export default function Login() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />

--- a/src/react-app/pages/Register.tsx
+++ b/src/react-app/pages/Register.tsx
@@ -213,6 +213,7 @@ export default function Register() {
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />
@@ -277,6 +278,7 @@ export default function Register() {
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition"
+                    aria-label={showConfirmPassword ? 'Hide confirm password' : 'Show confirm password'}
                   >
                     {showConfirmPassword ? (
                       <EyeOff className="h-4 w-4" />


### PR DESCRIPTION
**💡 What:** Added dynamic `aria-label` attributes (e.g., `aria-label={showPassword ? 'Hide password' : 'Show password'}`) to the eye icon buttons in the Login and Register forms.
**🎯 Why:** Icon-only buttons used for state toggling (like showing/hiding a password) are completely opaque to screen reader users if they don't have text labels. Furthermore, a static label like "Toggle password" is less helpful than a dynamic one that explicitly describes the action that will occur ("Show password" when hidden, "Hide password" when visible).
**📸 Before/After:** Before, the eye icons were `button`s without any text or labels. After, they announce their specific action.
**♿ Accessibility:** Screen readers will now correctly announce "Show password, button" or "Hide password, button" when focusing these toggles, greatly improving the form's usability for visually impaired users.

---
*PR created automatically by Jules for task [14140802596426584999](https://jules.google.com/task/14140802596426584999) started by @njtan142*