### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-03-09 - Missing ARIA labels in dynamic UI component toggles
+**Learning:** Icon-only toggle buttons in layout components (like the `ChevronRight`/`ChevronLeft` button in `src/components/ui/tools-panel.tsx`) and quick-action icon buttons (like "Save/Cancel edit" and "Regenerate title" in `attachment-menu.tsx`) frequently lack `aria-label` attributes. Screen reader users would have no context for what these buttons do since they lack text nodes. Furthermore, for toggle buttons, dynamically updating the label (e.g. `aria-label={isOpen ? "Close tools panel" : "Open tools panel"}`) provides a much clearer experience than a static generic label.
+**Action:** Always provide `aria-label` for any `<Button size="icon">`. For buttons that toggle state, try to use a dynamic label that accurately describes the action the button will perform in its current state.

--- a/src/components/ui/attachment-menu.tsx
+++ b/src/components/ui/attachment-menu.tsx
@@ -369,6 +369,7 @@ function IdeaSelectorDialog({
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7"
+                          aria-label="Save title"
                           onClick={(e) => handleSaveEdit(idea, e)}
                           disabled={isUpdating}
                         >
@@ -382,6 +383,7 @@ function IdeaSelectorDialog({
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7"
+                          aria-label="Cancel editing"
                           onClick={handleCancelEdit}
                           disabled={isUpdating}
                         >
@@ -403,6 +405,7 @@ function IdeaSelectorDialog({
                           variant="ghost"
                           size="icon"
                           className="h-6 w-6 shrink-0"
+                          aria-label="Edit title"
                           onClick={(e) => handleStartEdit(idea, e)}
                           title="Edit title"
                         >
@@ -412,6 +415,7 @@ function IdeaSelectorDialog({
                           variant="ghost"
                           size="icon"
                           className="h-6 w-6 shrink-0"
+                          aria-label="Regenerate title with AI"
                           onClick={(e) => handleRegenerateTitle(idea, e)}
                           disabled={regeneratingId === idea.id || !idea.description}
                           title="Regenerate title with AI"

--- a/src/components/ui/tools-panel.tsx
+++ b/src/components/ui/tools-panel.tsx
@@ -52,6 +52,7 @@ export const ToolsPanel: React.FC<ToolsPanelProps> = ({
       <Button
         variant="ghost"
         size="icon"
+        aria-label={isOpen ? "Close tools panel" : "Open tools panel"}
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
           "absolute top-4 z-10 h-8 w-8 rounded-full border bg-background shadow-sm hover:bg-muted transition-all duration-300",


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to five icon-only buttons across `tools-panel.tsx` and `attachment-menu.tsx`. The toggle button in `tools-panel.tsx` now has a dynamic ARIA label indicating whether it will open or close the panel.
🎯 Why: Screen reader users previously had no context for what these icon-only buttons did since they lacked text content. Providing descriptive, action-oriented ARIA labels improves accessibility and clarity for keyboard/screen reader navigation.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Ensures that `ChevronLeft`/`ChevronRight`, `Pencil`, `Sparkles`, `Check`, and `X` icon buttons are properly announced by assistive technologies.

---
*PR created automatically by Jules for task [9383639863842084288](https://jules.google.com/task/9383639863842084288) started by @njtan142*