### PR TITLE
⚡ Bolt: [performance improvement] Resolve N+1 query bottleneck in analytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+
+## 2026-04-10 - N+1 Bottleneck in Cloudflare D1 / SQLite Promise.all Mapping
+**Learning:** Resolving N+1 database queries that occur inside `Promise.all` loops where an expensive related query is performed per item (e.g., fetching top 3 results per query string) can be elegantly solved in Cloudflare D1 / SQLite. Using `ROW_NUMBER() OVER(PARTITION BY ...)` allows grouping and limiting the related records across multiple parent entities in a single bulk query with an `IN (...)` clause.
+**Action:** When replacing N+1 `.map` loops with a bulk `IN (...)` query, always include an early return check (e.g., `if (results.length === 0) return []`) to prevent SQL syntax errors from attempting to bind an empty parameter list to the `IN` clause.

--- a/src/tests/enhanced-search-history-manager.test.ts
+++ b/src/tests/enhanced-search-history-manager.test.ts
@@ -341,7 +341,8 @@ describe('EnhancedSearchHistoryManager', () => {
         {
           result_title: 'Deep Learning for NLP',
           relevance_score: 0.95,
-          added_to_library: true
+          added_to_library: true,
+          search_query: 'machine learning'
         }
       ];
 
@@ -677,12 +678,14 @@ describe('EnhancedSearchHistoryManager', () => {
           {
             result_title: 'Advanced ML Techniques',
             relevance_score: 0.92,
-            added_to_library: true
+            added_to_library: true,
+            search_query: 'machine learning research'
           },
           {
             result_title: 'ML in Healthcare',
             relevance_score: 0.88,
-            added_to_library: false
+            added_to_library: false,
+            search_query: 'machine learning research'
           }
         ];
 

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -316,42 +316,58 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
+      const results = result.results || [];
+      if (results.length === 0) {
+        return [];
+      }
+
+      const searchQueries = results.map((row: any) => row.search_query);
+
+      // Get top results for all queries in a single query using ROW_NUMBER()
+      const topResultsQuery = `
+        SELECT result_title, relevance_score, added_to_library, search_query
+        FROM (
+          SELECT sr.result_title, sr.relevance_score, sr.added_to_library, ss.search_query,
+                 ROW_NUMBER() OVER(PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.search_query IN (${searchQueries.map(() => '?').join(', ')})
+            AND ss.user_id = ?
             ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+        )
+        WHERE rn <= 3
+        ORDER BY search_query, relevance_score DESC
+      `;
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      const topResultsParams = [...searchQueries, userId];
+      if (conversationId) {
+        topResultsParams.push(conversationId);
+      }
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      const topResultsByQuery = new Map<string, Array<{title: string, relevanceScore: number, addedToLibrary: boolean}>>();
+      (topResultsResult.results || []).forEach((row: any) => {
+        const queryStr = row.search_query;
+        if (!topResultsByQuery.has(queryStr)) {
+          topResultsByQuery.set(queryStr, []);
+        }
+        topResultsByQuery.get(queryStr)!.push({
+          title: row.result_title,
+          relevanceScore: row.relevance_score,
+          addedToLibrary: row.added_to_library
+        });
+      });
+
+      const queryAnalytics = results.map((row: any) => ({
+        query: row.search_query,
+        searchCount: row.search_count,
+        averageResults: row.avg_results || 0,
+        successRate: row.success_rate || 0,
+        averageProcessingTime: row.avg_processing_time || 0,
+        lastUsed: new Date(row.last_used),
+        topResults: topResultsByQuery.get(row.search_query) || []
+      }));
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
💡 What: Replaced an N+1 query bottleneck inside a `Promise.all` `.map` loop in `EnhancedSearchHistoryManager.getQueryPerformanceAnalytics` with a single, grouped database query utilizing `ROW_NUMBER() OVER(PARTITION BY ...)`.
🎯 Why: Iteratively querying the database for related top search results for each matching query created N+1 query overhead, blocking execution and heavily taxing the Cloudflare D1 environment.
📊 Impact: Reduces database queries from O(N) to O(1) for this specific workflow, providing vastly superior throughput when analyzing multiple distinct query performance records.
🔬 Measurement: Verify by executing the `getQueryPerformanceAnalytics` tests in `src/tests/enhanced-search-history-manager.test.ts`. Tests pass correctly, reflecting the identical output with a highly optimized data-fetching method.

---
*PR created automatically by Jules for task [261427830759128365](https://jules.google.com/task/261427830759128365) started by @njtan142*