### PR TITLE
⚡ Bolt: [performance improvement] Resolve N+1 bottleneck in search analytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+## 2024-05-18 - Avoid breaking package.json for test environment
+**Learning:** Adding new runtime dependencies like \`sqlite3\` directly to \`package.json\` in order to run isolated test scripts can break the Cloudflare worker build and cause CI failures. The worker environment relies on \`@cloudflare/workers-types\` or specific bindings instead.
+**Action:** Never add dependencies to \`package.json\` just for scratchpad scripts; instead, either mock the behavior, run the existing unit tests with \`bun test\`, or clean up test scripts without saving them to the lockfile.

--- a/src/tests/enhanced-search-history-manager.test.ts
+++ b/src/tests/enhanced-search-history-manager.test.ts
@@ -339,6 +339,7 @@ describe('EnhancedSearchHistoryManager', () => {
 
       const mockTopResults = [
         {
+          search_query: 'machine learning',
           result_title: 'Deep Learning for NLP',
           relevance_score: 0.95,
           added_to_library: true
@@ -675,11 +676,25 @@ describe('EnhancedSearchHistoryManager', () => {
 
         const mockTopResults = [
           {
+            search_query: 'machine learning research',
             result_title: 'Advanced ML Techniques',
             relevance_score: 0.92,
             added_to_library: true
           },
           {
+            search_query: 'machine learning research',
+            result_title: 'ML in Healthcare',
+            relevance_score: 0.88,
+            added_to_library: false
+          },
+          {
+            search_query: 'data analysis methods',
+            result_title: 'Advanced ML Techniques',
+            relevance_score: 0.92,
+            added_to_library: true
+          },
+          {
+            search_query: 'data analysis methods',
             result_title: 'ML in Healthcare',
             relevance_score: 0.88,
             added_to_library: false
@@ -688,7 +703,6 @@ describe('EnhancedSearchHistoryManager', () => {
 
         mockPrepare.all
           .mockResolvedValueOnce({ results: mockPerformanceData })
-          .mockResolvedValueOnce({ results: mockTopResults })
           .mockResolvedValueOnce({ results: mockTopResults });
 
         const analytics = await manager.getQueryPerformanceAnalytics('user-1', 'conv-1', 30);

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -315,43 +315,57 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
       `;
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
+      const rows = result.results || [];
+
+      if (rows.length === 0) return [];
+
+      // Get top results for all queries in a single query to prevent N+1 bottleneck
+      const searchQueries = rows.map((r: any) => r.search_query);
+      const placeholders = searchQueries.map(() => '?').join(', ');
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
-            ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+      const topResultsQuery = `
+        SELECT * FROM (
+          SELECT
+            sr.result_title,
+            sr.relevance_score,
+            sr.added_to_library,
+            ss.search_query,
+            ROW_NUMBER() OVER (PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.search_query IN (${placeholders}) AND ss.user_id = ?
+          ${conversationId ? 'AND ss.conversation_id = ?' : ''}
+        )
+        WHERE rn <= 3
+      `;
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      const topResultsParams = [...searchQueries, userId];
+      if (conversationId) {
+        topResultsParams.push(conversationId);
+      }
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      const resultsMap = new Map<string, any[]>();
+      searchQueries.forEach(sq => resultsMap.set(sq, []));
+
+      (topResultsResult.results || []).forEach((r: any) => {
+        resultsMap.get(r.search_query)?.push({
+          title: r.result_title,
+          relevanceScore: r.relevance_score,
+          addedToLibrary: r.added_to_library
+        });
+      });
+
+      const queryAnalytics = rows.map((row: any) => ({
+        query: row.search_query,
+        searchCount: row.search_count,
+        averageResults: row.avg_results || 0,
+        successRate: row.success_rate || 0,
+        averageProcessingTime: row.avg_processing_time || 0,
+        lastUsed: new Date(row.last_used),
+        topResults: resultsMap.get(row.search_query) || []
+      }));
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
💡 **What**: Refactored `getQueryPerformanceAnalytics` to eliminate N+1 database queries by fetching top results in a single batched query using the SQLite `ROW_NUMBER() OVER (PARTITION BY ...)` window function.
🎯 **Why**: The existing implementation iterated over results and performed individual DB calls inside a `Promise.all`, creating significant overhead when scaling the number of queries.
📊 **Impact**: Reduces database round-trips from O(N) to O(1) for this operation. This prevents connection exhaustion and dramatically improves average processing time for the analytics dashboard when many queries exist.
🔬 **Measurement**: Verified with the `src/tests/enhanced-search-history-manager.test.ts` suite via `bun test` and verified that the mock execution now correctly asserts just 1 secondary bulk query instead of N.

---
*PR created automatically by Jules for task [13625418725575437530](https://jules.google.com/task/13625418725575437530) started by @njtan142*