### PR TITLE
⚡ Bolt: Fix N+1 queries in getQueryPerformanceAnalytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+## 2026-04-15 - [Optimize N+1 DB Queries]
+**Learning:** Using window functions like `ROW_NUMBER() OVER(PARTITION BY ...)` with an `IN ()` clause allows efficient batching of N+1 database queries when fetching top N results for multiple distinct queries.
+**Action:** Prioritize batching with window functions when iterating over a list of items to retrieve top associated records from SQLite/D1.

--- a/src/tests/enhanced-search-history-manager.test.ts
+++ b/src/tests/enhanced-search-history-manager.test.ts
@@ -339,6 +339,7 @@ describe('EnhancedSearchHistoryManager', () => {
 
       const mockTopResults = [
         {
+          search_query: 'machine learning',
           result_title: 'Deep Learning for NLP',
           relevance_score: 0.95,
           added_to_library: true
@@ -675,11 +676,25 @@ describe('EnhancedSearchHistoryManager', () => {
 
         const mockTopResults = [
           {
+            search_query: 'machine learning research',
             result_title: 'Advanced ML Techniques',
             relevance_score: 0.92,
             added_to_library: true
           },
           {
+            search_query: 'machine learning research',
+            result_title: 'ML in Healthcare',
+            relevance_score: 0.88,
+            added_to_library: false
+          },
+          {
+            search_query: 'deep learning applications',
+            result_title: 'Advanced ML Techniques',
+            relevance_score: 0.92,
+            added_to_library: true
+          },
+          {
+            search_query: 'deep learning applications',
             result_title: 'ML in Healthcare',
             relevance_score: 0.88,
             added_to_library: false
@@ -688,7 +703,6 @@ describe('EnhancedSearchHistoryManager', () => {
 
         mockPrepare.all
           .mockResolvedValueOnce({ results: mockPerformanceData })
-          .mockResolvedValueOnce({ results: mockTopResults })
           .mockResolvedValueOnce({ results: mockTopResults });
 
         const analytics = await manager.getQueryPerformanceAnalytics('user-1', 'conv-1', 30);

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -316,42 +316,51 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
-            ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+      const rows = result.results || [];
+      if (rows.length === 0) return [];
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      // ⚡ Bolt: Fixed N+1 queries using ROW_NUMBER window function to batch fetch top results for all queries
+      const searchQueries = rows.map((r: any) => r.search_query);
+      const placeholders = searchQueries.map(() => '?').join(',');
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      const topResultsParams = [...searchQueries, userId];
+      if (conversationId) {
+        topResultsParams.push(conversationId);
+      }
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      const topResultsQuery = `
+        SELECT * FROM (
+          SELECT ss.search_query, sr.result_title, sr.relevance_score, sr.added_to_library,
+                 ROW_NUMBER() OVER (PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.search_query IN (${placeholders}) AND ss.user_id = ?
+          ${conversationId ? 'AND ss.conversation_id = ?' : ''}
+        )
+        WHERE rn <= 3
+      `;
+
+      const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
+
+      const resultsByQuery = (topResultsResult.results || []).reduce((acc: any, r: any) => {
+        if (!acc[r.search_query]) acc[r.search_query] = [];
+        acc[r.search_query].push({
+          title: r.result_title,
+          relevanceScore: r.relevance_score,
+          addedToLibrary: r.added_to_library
+        });
+        return acc;
+      }, {});
+
+      const queryAnalytics = rows.map((row: any) => ({
+        query: row.search_query,
+        searchCount: row.search_count,
+        averageResults: row.avg_results || 0,
+        successRate: row.success_rate || 0,
+        averageProcessingTime: row.avg_processing_time || 0,
+        lastUsed: new Date(row.last_used),
+        topResults: resultsByQuery[row.search_query] || []
+      }));
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
💡 What: Replaced an N+1 query loop in `getQueryPerformanceAnalytics` (which fired an extra query for every `search_query` in the array) with a single batched query using the `ROW_NUMBER() OVER (PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC)` window function and an `IN ()` clause. 
🎯 Why: Iterating over an array and executing a database query in every iteration creates N+1 latency, which scales poorly and blocks the backend worker. Batching reduces the database roundtrips from N+1 to strictly 2.
📊 Impact: Reduces database queries from O(N) to O(1) in the performance analytics endpoint, preventing scaling bottlenecks and decreasing average response time.
🔬 Measurement: Verify by executing `pnpm test src/tests/enhanced-search-history-manager.test.ts`. The updated tests verify that the mocked database driver is only called once for the batched result set instead of multiple times.

---
*PR created automatically by Jules for task [4925943835588437566](https://jules.google.com/task/4925943835588437566) started by @njtan142*