### PR TITLE
⚡ Bolt: [performance improvement] fix N+1 query in getQueryPerformanceAnalytics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-22 - Redundant Array Traversals in getStatistics
 **Learning:** Performing multiple consecutive `.filter().length` operations on an array of objects where each filter condition involves an expensive operation (like `safeDate` parsing) leads to (kN)$ time complexity and redundant processing.
 **Action:** Consolidate multiple statistics calculations into a single (N)$ pass using a single loop (e.g., `forEach` or `reduce`). This minimizes traversals and ensures each expensive transformation (like date parsing) is performed exactly once per element.
+
+## 2026-04-17 - N+1 Queries in Promise.all loops
+**Learning:** Using `Promise.all(array.map(...))` to execute N database queries (e.g., fetching top results for N search queries) creates an N+1 bottleneck, consuming excess database connections and increasing latency.
+**Action:** Replace N+1 queries by executing a single batched query using `IN (...)` with window functions like `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)` to group and filter results in SQL, then reconstruct the map in memory. Always ensure an early return for empty result sets to prevent SQL syntax errors from empty `IN ()` clauses.

--- a/src/tests/enhanced-search-history-manager.test.ts
+++ b/src/tests/enhanced-search-history-manager.test.ts
@@ -339,6 +339,7 @@ describe('EnhancedSearchHistoryManager', () => {
 
       const mockTopResults = [
         {
+          search_query: 'machine learning',
           result_title: 'Deep Learning for NLP',
           relevance_score: 0.95,
           added_to_library: true
@@ -675,11 +676,25 @@ describe('EnhancedSearchHistoryManager', () => {
 
         const mockTopResults = [
           {
+            search_query: 'machine learning research',
             result_title: 'Advanced ML Techniques',
             relevance_score: 0.92,
             added_to_library: true
           },
           {
+            search_query: 'machine learning research',
+            result_title: 'ML in Healthcare',
+            relevance_score: 0.88,
+            added_to_library: false
+          },
+          {
+            search_query: 'deep learning applications',
+            result_title: 'Advanced ML Techniques',
+            relevance_score: 0.92,
+            added_to_library: true
+          },
+          {
+            search_query: 'deep learning applications',
             result_title: 'ML in Healthcare',
             relevance_score: 0.88,
             added_to_library: false
@@ -688,7 +703,6 @@ describe('EnhancedSearchHistoryManager', () => {
 
         mockPrepare.all
           .mockResolvedValueOnce({ results: mockPerformanceData })
-          .mockResolvedValueOnce({ results: mockTopResults })
           .mockResolvedValueOnce({ results: mockTopResults });
 
         const analytics = await manager.getQueryPerformanceAnalytics('user-1', 'conv-1', 30);

--- a/src/worker/lib/enhanced-search-history-manager.ts
+++ b/src/worker/lib/enhanced-search-history-manager.ts
@@ -316,42 +316,61 @@ export class EnhancedSearchHistoryManager extends SearchAnalyticsManager {
 
       const result = await this.getEnvironment().DB.prepare(query).bind(...params).all();
       
-      // Get top results for each query
-      const queryAnalytics = await Promise.all(
-        (result.results || []).map(async (row: any) => {
-          const topResultsQuery = `
-            SELECT sr.result_title, sr.relevance_score, sr.added_to_library
-            FROM search_results sr
-            JOIN search_sessions ss ON sr.search_session_id = ss.id
-            WHERE ss.search_query = ? AND ss.user_id = ?
-            ${conversationId ? 'AND ss.conversation_id = ?' : ''}
-            ORDER BY sr.relevance_score DESC
-            LIMIT 3
-          `;
+      const queries = result.results || [];
+      if (queries.length === 0) return [];
 
-          const topResultsParams = [row.search_query, userId];
-          if (conversationId) {
-            topResultsParams.push(conversationId);
-          }
+      const searchQueries = queries.map((r: any) => r.search_query);
+      const queryPlaceholders = searchQueries.map(() => '?').join(',');
 
-          const topResultsResult = await this.getEnvironment().DB.prepare(topResultsQuery).bind(...topResultsParams).all();
-          const topResults = (topResultsResult.results || []).map((r: any) => ({
-            title: r.result_title,
-            relevanceScore: r.relevance_score,
-            addedToLibrary: r.added_to_library
-          }));
+      // ⚡ Bolt Optimization: Replacing N+1 DB queries inside a Promise.all map loop
+      // with a single batched query using ROW_NUMBER() window function.
+      // This reduces database connections from O(N) to O(1) and decreases latency.
+      // The outer ORDER BY ensures that the returned results are correctly sorted.
+      const batchedTopResultsQuery = `
+        SELECT * FROM (
+          SELECT
+            ss.search_query,
+            sr.result_title,
+            sr.relevance_score,
+            sr.added_to_library,
+            ROW_NUMBER() OVER(PARTITION BY ss.search_query ORDER BY sr.relevance_score DESC) as rn
+          FROM search_results sr
+          JOIN search_sessions ss ON sr.search_session_id = ss.id
+          WHERE ss.search_query IN (${queryPlaceholders}) AND ss.user_id = ?
+          ${conversationId ? 'AND ss.conversation_id = ?' : ''}
+        )
+        WHERE rn <= 3
+        ORDER BY search_query, rn ASC
+      `;
 
-          return {
-            query: row.search_query,
-            searchCount: row.search_count,
-            averageResults: row.avg_results || 0,
-            successRate: row.success_rate || 0,
-            averageProcessingTime: row.avg_processing_time || 0,
-            lastUsed: new Date(row.last_used),
-            topResults
-          };
-        })
-      );
+      const batchedParams = [...searchQueries, userId];
+      if (conversationId) {
+        batchedParams.push(conversationId);
+      }
+
+      const batchedTopResultsResult = await this.getEnvironment().DB.prepare(batchedTopResultsQuery).bind(...batchedParams).all();
+
+      const topResultsMap = new Map<string, any[]>();
+      (batchedTopResultsResult.results || []).forEach((r: any) => {
+        if (!topResultsMap.has(r.search_query)) {
+          topResultsMap.set(r.search_query, []);
+        }
+        topResultsMap.get(r.search_query)!.push({
+          title: r.result_title,
+          relevanceScore: r.relevance_score,
+          addedToLibrary: r.added_to_library
+        });
+      });
+
+      const queryAnalytics = queries.map((row: any) => ({
+        query: row.search_query,
+        searchCount: row.search_count,
+        averageResults: row.avg_results || 0,
+        successRate: row.success_rate || 0,
+        averageProcessingTime: row.avg_processing_time || 0,
+        lastUsed: new Date(row.last_used),
+        topResults: topResultsMap.get(row.search_query) || []
+      }));
 
       return queryAnalytics;
     } catch (error) {


### PR DESCRIPTION
**💡 What**: 
Replaced an N+1 `Promise.all(array.map(...))` database lookup loop with a single batched SQL query using the `ROW_NUMBER() OVER(PARTITION BY ...)` window function in `src/worker/lib/enhanced-search-history-manager.ts`. Reconstructs the results mapped by `search_query` in memory. Also added an early return for empty result sets to prevent SQL `IN ()` syntax errors.

**🎯 Why**: 
The `getQueryPerformanceAnalytics` method previously mapped over N distinct search queries, executing a new database call for the top 3 results for each one. In an environment like Cloudflare D1/SQLite where latency or connection overhead scales with the number of discrete queries, this N+1 pattern creates a significant processing bottleneck for users with a rich history of distinct search queries. 

**📊 Impact**: 
Reduces database queries required for top result fetching from O(N) down to O(1) single query per analytical sweep. Noticeably reduces the `averageProcessingTime` footprint for users heavily utilizing the AI search manager.

**🔬 Measurement**: 
Can be verified by monitoring network logs or query execution counts against D1 when invoking `getQueryPerformanceAnalytics`. Locally verified via `bun test src/tests/enhanced-search-history-manager.test.ts` where tests assert the batched mocks correctly hydrate analytics.

---
*PR created automatically by Jules for task [6811992529839628833](https://jules.google.com/task/6811992529839628833) started by @njtan142*