### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in ReferenceForm

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - ReferenceForm aria-labels
+**Learning:** Icon-only buttons used for actions such as close, add tag, and remove item lack accessibility and require dynamic or explicit aria-label attributes. This applies broadly to shadcn UI icons and Buttons.
+**Action:** Always ensure icon-only buttons receive descriptive aria-label attributes when used in components.

--- a/src/components/ui/reference-form.tsx
+++ b/src/components/ui/reference-form.tsx
@@ -229,7 +229,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
           <CardTitle>
             {isEditing ? 'Edit Reference' : 'Add New Reference'}
           </CardTitle>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close reference form">
             <X className="h-4 w-4" />
           </Button>
         </div>
@@ -282,7 +282,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   placeholder="Add author name"
                   onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addAuthor())}
                 />
-                <Button type="button" onClick={addAuthor} size="sm">
+                <Button type="button" onClick={addAuthor} size="sm" aria-label="Add author">
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -294,6 +294,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeAuthor(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove author"
                     >
                       <X className="h-3 w-3" />
                     </button>
@@ -454,7 +455,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   placeholder="Add tag"
                   onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
                 />
-                <Button type="button" onClick={addTag} size="sm">
+                <Button type="button" onClick={addTag} size="sm" aria-label="Add tag">
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -466,6 +467,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeTag(index)}
                       className="hover:text-destructive"
+                      aria-label="Remove tag"
                     >
                       <X className="h-3 w-3" />
                     </button>


### PR DESCRIPTION
## What
Added `aria-label` attributes to the icon-only buttons in the `ReferenceForm` component. Specifically:
- `aria-label="Close reference form"` to the close button.
- `aria-label="Add author"` to the author input add button.
- `aria-label="Remove author"` to the author badge remove buttons.
- `aria-label="Add tag"` to the tag input add button.
- `aria-label="Remove tag"` to the tag badge remove buttons.

## Why
Icon-only buttons rely entirely on visual context (the SVG icon) to communicate their purpose. Screen readers cannot interpret these SVGs effectively, leading to a poor accessibility experience where the button's function is unclear to visually impaired users.

## Accessibility
These changes provide explicit, screen-reader-friendly text for actions that previously lacked semantics, improving the form's overall accessibility.

---
*PR created automatically by Jules for task [5600224714527888435](https://jules.google.com/task/5600224714527888435) started by @njtan142*