### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in ReferenceForm

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-09 - Missing ARIA labels in dynamic/interactive chat components
 **Learning:** Icon-only buttons in the core Chat component (`src/components/ui/chat.tsx`), particularly actions like "Thumbs up", "Thumbs down", and "Scroll to bottom", were missing `aria-label` attributes. Screen reader users would have no context for what these buttons do since they lack text nodes.
 **Action:** When implementing new features or components with interactive icon-only buttons (`size="icon"`), proactively add descriptive `aria-label` attributes.
+
+## 2026-03-09 - Add ARIA labels to icon-only buttons in ReferenceForm
+**Learning:** When generating interactive elements in loops like authors and tags, dynamic `aria-label`s must be used to give context to screen readers, especially when the visual representation relies on icons (like an 'X' button).
+**Action:** Ensure dynamic `aria-label` attributes are added to any interactive mapped elements.

--- a/src/components/ui/reference-form.tsx
+++ b/src/components/ui/reference-form.tsx
@@ -229,7 +229,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
           <CardTitle>
             {isEditing ? 'Edit Reference' : 'Add New Reference'}
           </CardTitle>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close">
             <X className="h-4 w-4" />
           </Button>
         </div>
@@ -282,7 +282,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   placeholder="Add author name"
                   onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addAuthor())}
                 />
-                <Button type="button" onClick={addAuthor} size="sm">
+                <Button type="button" onClick={addAuthor} size="sm" aria-label="Add author">
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -294,6 +294,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeAuthor(index)}
                       className="hover:text-destructive"
+                      aria-label={`Remove author ${typeof author === 'string' ? author : `${author.firstName} ${author.lastName}`}`}
                     >
                       <X className="h-3 w-3" />
                     </button>
@@ -454,7 +455,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                   placeholder="Add tag"
                   onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
                 />
-                <Button type="button" onClick={addTag} size="sm">
+                <Button type="button" onClick={addTag} size="sm" aria-label="Add tag">
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -466,6 +467,7 @@ export const ReferenceForm: React.FC<ReferenceFormProps> = ({
                       type="button"
                       onClick={() => removeTag(index)}
                       className="hover:text-destructive"
+                      aria-label={`Remove tag ${tag}`}
                     >
                       <X className="h-3 w-3" />
                     </button>


### PR DESCRIPTION
💡 What: Added accessible `aria-label` attributes to the icon-only buttons in the `ReferenceForm` component. Specifically added static labels to the `Close`, `Add author`, and `Add tag` buttons, and context-aware dynamic labels to the mapped `Remove author` and `Remove tag` buttons.

🎯 Why: Icon-only buttons lack inherent context for users employing assistive technologies like screen readers. Adding precise ARIA labels provides clear intent for these actions. Dynamic labels generated in maps ensure users know exactly which author or tag is being removed.

♿ Accessibility: Significantly improves keyboard and screen-reader usability for managing authors and tags when creating references.

---
*PR created automatically by Jules for task [7853650099777475285](https://jules.google.com/task/7853650099777475285) started by @njtan142*